### PR TITLE
feat(scraper): add scraper search endpoint

### DIFF
--- a/HomeLabManager.API/Controllers/ScraperController.cs
+++ b/HomeLabManager.API/Controllers/ScraperController.cs
@@ -1,0 +1,30 @@
+﻿using HomeLabManager.API.Models;
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace HomeLabManager.API.Controllers
+{
+
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ScraperController : ControllerBase
+    {
+        private readonly IScraperService _scraperService;
+
+        public ScraperController(IScraperService scraperService)
+        {
+            _scraperService = scraperService;
+        }
+
+        //maps to POST api/scraper/search, this is the endpoint that the frontend will call when the user wants to search for a device, it will pass the search term in the body of the request as a ScraperSearchRequest object which contains a single property Query that is the search term, this will then be passed to the scraper service which will then pass it to the providers to search for a match and return the result back to the frontend
+        [HttpPost("search")]
+        public async Task<ActionResult> Search([FromBody] ScraperSearchRequest request)
+        {
+            var result = await _scraperService.LookupDeviceAsync(request.Query);
+            return Ok(result);
+        }
+        
+    }
+    
+}

--- a/HomeLabManager.API/Models/ScraperSearchRequest.cs
+++ b/HomeLabManager.API/Models/ScraperSearchRequest.cs
@@ -1,0 +1,6 @@
+namespace HomeLabManager.API.Models;
+
+public class ScraperSearchRequest
+{
+    public string Query { get; set; }= string.Empty;
+}


### PR DESCRIPTION
This pull request introduces a new API endpoint for searching devices via a scraping service, along with its corresponding request model. The main focus is on enabling the frontend to send search queries to the backend, which are then processed by the scraping service.

**New API endpoint for device search:**

* Added `ScraperController` with a `POST api/scraper/search` endpoint that accepts a `ScraperSearchRequest` containing a search query, invokes the `IScraperService.LookupDeviceAsync` method, and returns the result.

**Supporting request model:**

* Introduced the `ScraperSearchRequest` model with a single `Query` property to represent the user's search term in request bodies.