### PR TITLE
feature(scraper): add UPC database lookup provider

### DIFF
--- a/HomeLabManager.API/HomeLabManager.API.csproj
+++ b/HomeLabManager.API/HomeLabManager.API.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>93c6af4b-a1ad-4deb-b168-f4949d601af7</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HomeLabManager.API/Models/UpcDatabaseResponse.cs
+++ b/HomeLabManager.API/Models/UpcDatabaseResponse.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace HomeLabManager.API.Models
+{
+    public class UpcDatabaseResponse
+    {
+ [JsonPropertyName("barcode")]
+        public string Barcode { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; } = string.Empty;
+
+        [JsonPropertyName("brand")]
+        public string Brand { get; set; } = string.Empty;
+
+        [JsonPropertyName("manufacturer")]
+        public string Manufacturer { get; set; } = string.Empty;
+
+        [JsonPropertyName("category")]
+        public string Category { get; set; } = string.Empty;
+        
+    }
+}

--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -5,7 +5,7 @@ using HomeLabManager.API.Interfaces;
 using HomeLabManager.API.Services;
 using HomeLabManager.API.Services.Scraping;
 using HomeLabManager.API.Services.Scraping.Interfaces;
-using HomeLabManager.API.Services.Providers;
+using HomeLabManager.API.Services.Scraping.Providers;
 
 namespace HomeLabManager.API
 {
@@ -46,7 +46,10 @@ namespace HomeLabManager.API
             builder.Services.AddScoped<IScraperService, ScraperService>();
       
             //Hardware lookup providers - this is where we can add multiple providers and the scraper service will use them in order until it finds a match
+            builder.Services.AddHttpClient<UpcLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
+
             
             //ComponentRespositoryInterface, ComponentRepository: Maps interface to implementation
             builder.Services.AddScoped<ComponentRepositoryInterface, ComponentRepository>();

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeHardwareLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeHardwareLookupProvider.cs
@@ -3,7 +3,7 @@ using HomeLabManager.Core.Scraping.DTOs;
 using HomeLabManager.Core.Scraping.Enums;
 using HomeLabManager.Core.Scraping.Models;
 
-namespace HomeLabManager.API.Services.Providers
+namespace HomeLabManager.API.Services.Scraping.Providers
 {
     public class FakeHardwareLookupProvider : IHardwareLookupProvider
     {

--- a/HomeLabManager.API/Services/Scraping/Providers/UpcLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/UpcLookupProvider.cs
@@ -1,0 +1,119 @@
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.API.Models;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.Extensions.Configuration;
+using System.Text.Json;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    // This is a hardware lookup provider that uses the UPC Database API to look up devices based on their UPC code
+    public class UpcLookupProvider : IHardwareLookupProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly HttpClient _httpClient;
+        public UpcLookupProvider(IConfiguration configuration, HttpClient httpClient)
+        {
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }   
+        
+        public async Task<ScrapeResult> SearchAsync(string query)
+        {
+            var apiKey = _configuration["UpcDatabase:ApiKey"];
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "UPC Database API key is not configured."
+                };
+            }
+
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Query cannot be empty."
+                };
+            }
+
+        
+            var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"https://api.upcdatabase.org/product/{query}");
+
+            request.Headers.Authorization =
+                new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", apiKey);
+
+            var response = await _httpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"UPC Database request failed with status code {(int)response.StatusCode}."
+                };
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+
+            if (string.IsNullOrWhiteSpace(responseBody))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "UPC Database returned an empty response."
+                };
+            }
+            
+            // Deserialize the response into our UpcDatabaseResponse model
+            var upcResponse = JsonSerializer.Deserialize<UpcDatabaseResponse>(responseBody);
+
+            // If we couldn't parse the response, return a failed result
+            if (upcResponse == null)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "UPC Database response could not be parsed."
+                };
+            }
+
+            // If the title is empty, it means we didn't get a valid product back, so we can treat that as a failed search
+            if (string.IsNullOrWhiteSpace(upcResponse.Title))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "UPC Database returned no product title."
+                };
+            }
+
+            // If we got here, we have a successful response with product information, so we can return that in our ScrapeResult
+            return new ScrapeResult
+            {
+                Success = true,
+                Message = "UPC Database match found.",
+                DeviceInfo = new ScrapedDeviceInfo
+                {
+                    ProductName = upcResponse.Title,
+                    Manufacturer = !string.IsNullOrWhiteSpace(upcResponse.Manufacturer)
+                    ? upcResponse.Manufacturer : upcResponse.Brand,
+                    Description = upcResponse.Description,
+                    UPC = upcResponse.Barcode,
+                    Category = upcResponse.Category,
+                    SourceUrl = $"https://api.upcdatabase.org/product/{query}",
+                    SourceType = ScrapeSourceType.UpcDatabase
+                }
+            };
+
+        }
+    }
+}
+
+
+

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -1,5 +1,4 @@
 {
-//this is for defualt sqlite db context
     "ConnectionStrings": {
         "DefaultConnection": "Data Source=homelab.db"
     },
@@ -10,5 +9,8 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
-    "AllowedHosts": "*"
+    "AllowedHosts": "*",
+    "UpcDatabase":{ 
+        "ApiKey":""
+    }
 }


### PR DESCRIPTION
This pull request introduces a new hardware lookup provider that integrates with the UPC Database API, allowing the system to look up device information based on UPC codes. It also refactors provider namespaces for clarity and updates configuration to support the new provider. Below are the most important changes:

### New Feature: UPC Database Hardware Lookup

* Added `UpcLookupProvider` as a new implementation of `IHardwareLookupProvider`, which uses the UPC Database API to retrieve product information by UPC code. The provider handles API authentication, error cases, and maps the response into the system's device info model. (`HomeLabManager.API/Services/Scraping/Providers/UpcLookupProvider.cs`)
* Introduced the `UpcDatabaseResponse` model to deserialize responses from the UPC Database API. (`HomeLabManager.API/Models/UpcDatabaseResponse.cs`)

### Dependency Injection and Configuration

* Registered `UpcLookupProvider` and its required `HttpClient` in the DI container, and ensured it is used as an `IHardwareLookupProvider` alongside the fake provider. (`HomeLabManager.API/Program.cs`)
* Added a new section to `appsettings.json` for the UPC Database API key configuration. (`HomeLabManager.API/appsettings.json`)
* Set up user secrets support in the project file for secure storage of sensitive configuration like API keys. (`HomeLabManager.API/HomeLabManager.API.csproj`)

### Code Organization

* Refactored provider namespaces to move `FakeHardwareLookupProvider` into the `Scraping.Providers` namespace for consistency and clarity. (`HomeLabManager.API/Services/Scraping/Providers/FakeHardwareLookupProvider.cs`)
* Updated relevant `using` statements for the new provider namespace. (`HomeLabManager.API/Program.cs`)