### PR TITLE
feat: add Dell vendor routing scaffold

### DIFF
--- a/HomeLabManager.API/Controllers/ScraperController.cs
+++ b/HomeLabManager.API/Controllers/ScraperController.cs
@@ -24,7 +24,8 @@ namespace HomeLabManager.API.Controllers
         [HttpPost("search")]
         public async Task<ActionResult> Search([FromBody] ScraperSearchRequest request)
         {
-            var result = await _scraperService.LookupDeviceAsync(request.Query, "Upc");
+            var codeType = AnalyzeSearchQuery(request.Query);
+            var result = await _scraperService.LookupDeviceAsync(request.Query, codeType);
             return Ok(result);
         }
         
@@ -72,6 +73,7 @@ namespace HomeLabManager.API.Controllers
                 ExtractedCode = extractedCode,
                 LookupSucceeded = scrapeResult.Success,
                 Message = scrapeResult.Message,
+                DetectedVendor = scrapeResult.DetectedVendor,
                 ProductName = scrapeResult.DeviceInfo?.ProductName ?? string.Empty,
                 Manufacturer = scrapeResult.DeviceInfo?.Manufacturer ?? string.Empty,
                 ModelNumber = scrapeResult.DeviceInfo?.ModelNumber ?? string.Empty,
@@ -126,6 +128,21 @@ namespace HomeLabManager.API.Controllers
             }
 
             return ("Unknown", false, "Scanned code type is not supported for lookup.");
+        }
+
+        private static string AnalyzeSearchQuery(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return "Unknown";
+            }
+
+            if (query.All(char.IsDigit))
+            {
+                return "Upc";
+            }
+
+            return "SerialNumber";
         }
 
 

--- a/HomeLabManager.API/Models/ImageScrapePreviewResponse.cs
+++ b/HomeLabManager.API/Models/ImageScrapePreviewResponse.cs
@@ -10,6 +10,7 @@
         // These fields will indicate whether the lookup was successful and any messages from the providers, this will help the frontend determine how to display the results to the user, for example if the lookup failed it can show the extracted code and message to the user so they can try again with a clearer image or manually enter the code
         public bool LookupSucceeded { get; set; }
         public string Message { get; set; } = string.Empty;
+        public string DetectedVendor { get; set; } = string.Empty;
 
         // Device information fields that may be returned from the lookup, these will be populated if the lookup was successful and the provider was able to extract this information, otherwise they will be empty strings
         public string ProductName { get; set; } = string.Empty;

--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -47,8 +47,10 @@ namespace HomeLabManager.API
       
             //Hardware lookup providers - this is where we can add multiple providers and the scraper service will use them in order until it finds a match
             builder.Services.AddHttpClient<UpcLookupProvider>();
+            builder.Services.AddHttpClient<DellSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
             
             //ComponentRespositoryInterface, ComponentRepository: Maps interface to implementation

--- a/HomeLabManager.API/Services/Scraping/Interfaces/IHardwareLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Interfaces/IHardwareLookupProvider.cs
@@ -4,7 +4,7 @@ namespace HomeLabManager.API.Services.Scraping.Interfaces
 {
     public interface IHardwareLookupProvider
     {
-        bool CanHandle(string codeType);
-        Task<ScrapeResult> SearchAsync(string query);
+        bool CanHandle(string codeType, string? vendor = null);
+        Task<ScrapeResult> SearchAsync(string query, string? vendor = null);
     }
 }

--- a/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
@@ -1,0 +1,199 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    public class DellSerialLookupProvider : IHardwareLookupProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly HttpClient _httpClient;
+
+        public DellSerialLookupProvider(IConfiguration configuration, HttpClient httpClient)
+        {
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }
+
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            if (!string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.IsNullOrWhiteSpace(vendor)
+                || string.Equals(vendor, "Dell", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Serial number cannot be empty."
+                };
+            }
+
+            var isEnabled = _configuration.GetValue<bool?>("DellSupport:Enabled") ?? false;
+            if (!isEnabled)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Dell serial lookup is not enabled in configuration."
+                };
+            }
+
+            var lookupUrl = _configuration["DellSupport:LookupUrl"];
+            if (string.IsNullOrWhiteSpace(lookupUrl))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Dell serial lookup URL is not configured."
+                };
+            }
+
+            var requestUrl = BuildLookupUrl(lookupUrl, query);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Dell lookup request failed with status code {(int)response.StatusCode}."
+                };
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(responseBody))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Dell lookup returned an empty response."
+                };
+            }
+
+            try
+            {
+                using var document = JsonDocument.Parse(responseBody);
+                var root = document.RootElement;
+
+                var productName = ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title");
+                var manufacturer = ReadString(root, "manufacturer", "Manufacturer", "vendor", "Vendor");
+                var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model");
+                var description = ReadString(root, "description", "Description");
+                var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image");
+                var sourceUrl = ReadString(root, "sourceUrl", "SourceUrl", "url", "Url");
+
+                if (string.IsNullOrWhiteSpace(productName)
+                    && string.IsNullOrWhiteSpace(manufacturer)
+                    && string.IsNullOrWhiteSpace(modelNumber)
+                    && string.IsNullOrWhiteSpace(description))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Dell response did not contain recognized product fields."
+                    };
+                }
+
+                return new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Dell match found.",
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = productName,
+                        Manufacturer = manufacturer,
+                        ModelNumber = modelNumber,
+                        SerialNumber = query,
+                        Description = description,
+                        ImageUrl = imageUrl,
+                        SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? requestUrl : sourceUrl,
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                };
+            }
+            catch (JsonException)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Dell lookup response could not be parsed as JSON."
+                };
+            }
+        }
+
+        private static string BuildLookupUrl(string lookupUrl, string serial)
+        {
+            if (lookupUrl.Contains("{serial}", StringComparison.OrdinalIgnoreCase))
+            {
+                return lookupUrl.Replace("{serial}", Uri.EscapeDataString(serial), StringComparison.OrdinalIgnoreCase);
+            }
+
+            var separator = lookupUrl.Contains('?') ? "&" : "?";
+            return $"{lookupUrl}{separator}serial={Uri.EscapeDataString(serial)}";
+        }
+
+        private static string ReadString(JsonElement root, params string[] propertyNames)
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (TryReadProperty(root, propertyName, out var value))
+                {
+                    return value;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static bool TryReadProperty(JsonElement element, string propertyName, out string value)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        value = property.Value.ValueKind == JsonValueKind.String
+                            ? property.Value.GetString() ?? string.Empty
+                            : property.Value.ToString();
+                        return true;
+                    }
+
+                    if (TryReadProperty(property.Value, propertyName, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var child in element.EnumerateArray())
+                {
+                    if (TryReadProperty(child, propertyName, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            value = string.Empty;
+            return false;
+        }
+    }
+}

--- a/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using HomeLabManager.API.Services.Scraping.Interfaces;
 using HomeLabManager.Core.Scraping.DTOs;
 using HomeLabManager.Core.Scraping.Enums;
@@ -54,16 +56,19 @@ namespace HomeLabManager.API.Services.Scraping.Providers
             var lookupUrl = _configuration["DellSupport:LookupUrl"];
             if (string.IsNullOrWhiteSpace(lookupUrl))
             {
-                return new ScrapeResult
-                {
-                    Success = false,
-                    Message = "Dell serial lookup URL is not configured."
-                };
+                lookupUrl = "https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}/overview";
             }
 
             var requestUrl = BuildLookupUrl(lookupUrl, query);
             var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
-            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xml", 0.9));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/avif"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("image/webp"));
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36");
+            request.Headers.AcceptLanguage.ParseAdd("en-US,en;q=0.9");
+            request.Headers.Referrer = new Uri("https://www.dell.com/support/home/en-us");
 
             var response = await _httpClient.SendAsync(request);
             if (!response.IsSuccessStatusCode)
@@ -85,55 +90,71 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 };
             }
 
-            try
+            var html = WebUtility.HtmlDecode(responseBody);
+            var title = ExtractMetaContent(html, "property", "og:title");
+            var description = ExtractMetaContent(html, "name", "description");
+            var canonicalUrl = ExtractLinkHref(html, "canonical");
+            var pageTitle = ExtractTitle(html);
+
+            if (string.IsNullOrWhiteSpace(title))
             {
-                using var document = JsonDocument.Parse(responseBody);
+                title = pageTitle;
+            }
+
+            var structuredData = ExtractJsonLdDocuments(html);
+            foreach (var document in structuredData)
+            {
                 var root = document.RootElement;
 
-                var productName = ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title");
-                var manufacturer = ReadString(root, "manufacturer", "Manufacturer", "vendor", "Vendor");
-                var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model");
-                var description = ReadString(root, "description", "Description");
-                var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image");
-                var sourceUrl = ReadString(root, "sourceUrl", "SourceUrl", "url", "Url");
+                title = FirstNonEmpty(title, ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title"));
+                description = FirstNonEmpty(description, ReadString(root, "description", "Description"));
+                canonicalUrl = FirstNonEmpty(canonicalUrl, ReadString(root, "url", "Url", "sourceUrl", "SourceUrl"));
 
-                if (string.IsNullOrWhiteSpace(productName)
+                var manufacturer = ReadString(root, "manufacturer", "Manufacturer", "brand", "Brand", "vendor", "Vendor");
+                var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model", "sku", "Sku");
+                var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image", "thumbnailUrl", "ThumbnailUrl");
+
+                if (string.IsNullOrWhiteSpace(title)
                     && string.IsNullOrWhiteSpace(manufacturer)
                     && string.IsNullOrWhiteSpace(modelNumber)
                     && string.IsNullOrWhiteSpace(description))
                 {
-                    return new ScrapeResult
-                    {
-                        Success = false,
-                        Message = "Dell response did not contain recognized product fields."
-                    };
+                    continue;
                 }
 
                 return new ScrapeResult
                 {
                     Success = true,
-                    Message = "Dell match found.",
+                    Message = "Dell support page parsed successfully.",
                     DeviceInfo = new ScrapedDeviceInfo
                     {
-                        ProductName = productName,
+                        ProductName = title,
                         Manufacturer = manufacturer,
                         ModelNumber = modelNumber,
                         SerialNumber = query,
                         Description = description,
                         ImageUrl = imageUrl,
-                        SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? requestUrl : sourceUrl,
+                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? response.RequestMessage?.RequestUri?.ToString() ?? requestUrl : canonicalUrl,
                         SourceType = ScrapeSourceType.VendorWebsite
                     }
                 };
             }
-            catch (JsonException)
+
+            if (responseBody.Contains("Access Denied", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("403", StringComparison.OrdinalIgnoreCase))
             {
                 return new ScrapeResult
                 {
                     Success = false,
-                    Message = "Dell lookup response could not be parsed as JSON."
+                    Message = "Dell support page blocked the request."
                 };
             }
+
+            return new ScrapeResult
+            {
+                Success = false,
+                Message = "Dell support page did not contain recognized product information."
+            };
         }
 
         private static string BuildLookupUrl(string lookupUrl, string serial)
@@ -145,6 +166,69 @@ namespace HomeLabManager.API.Services.Scraping.Providers
 
             var separator = lookupUrl.Contains('?') ? "&" : "?";
             return $"{lookupUrl}{separator}serial={Uri.EscapeDataString(serial)}";
+        }
+
+        private static string ExtractTitle(string html)
+        {
+            var match = Regex.Match(html, @"<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            return match.Success ? WebUtility.HtmlDecode(match.Groups[1].Value).Trim() : string.Empty;
+        }
+
+        private static string ExtractMetaContent(string html, string attributeName, string attributeValue)
+        {
+            var pattern = $"<meta[^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*content\\s*=\\s*[\"'](?<content>.*?)[\"'][^>]*>|<meta[^>]*content\\s*=\\s*[\"'](?<content2>.*?)[\"'][^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var content = match.Groups["content"].Success ? match.Groups["content"].Value : match.Groups["content2"].Value;
+            return WebUtility.HtmlDecode(content).Trim();
+        }
+
+        private static string ExtractLinkHref(string html, string relValue)
+        {
+            var pattern = $"<link[^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*href\\s*=\\s*[\"'](?<href>.*?)[\"'][^>]*>|<link[^>]*href\\s*=\\s*[\"'](?<href2>.*?)[\"'][^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var href = match.Groups["href"].Success ? match.Groups["href"].Value : match.Groups["href2"].Value;
+            return WebUtility.HtmlDecode(href).Trim();
+        }
+
+        private static IEnumerable<JsonDocument> ExtractJsonLdDocuments(string html)
+        {
+            var documents = new List<JsonDocument>();
+            var matches = Regex.Matches(html, "<script[^>]*type=[\"']application/ld\\+json[\"'][^>]*>(?<json>.*?)</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            foreach (Match match in matches)
+            {
+                var jsonText = WebUtility.HtmlDecode(match.Groups["json"].Value).Trim();
+                if (string.IsNullOrWhiteSpace(jsonText))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    documents.Add(JsonDocument.Parse(jsonText));
+                }
+                catch (JsonException)
+                {
+                    continue;
+                }
+            }
+
+            return documents;
+        }
+
+        private static string FirstNonEmpty(params string[] values)
+        {
+            return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
         }
 
         private static string ReadString(JsonElement root, params string[] propertyNames)

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeHardwareLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeHardwareLookupProvider.cs
@@ -7,12 +7,12 @@ namespace HomeLabManager.API.Services.Scraping.Providers
 {
     public class FakeHardwareLookupProvider : IHardwareLookupProvider
     {
-        public bool CanHandle(string codeType)
+        public bool CanHandle(string codeType, string? vendor = null)
         {
             return string.Equals(codeType, "Upc", StringComparison.OrdinalIgnoreCase);
         }
 
-        public Task<ScrapeResult> SearchAsync(string query)
+        public Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
         {
              if (query == "test-device")
             {

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeSerialLookupProvider.cs
@@ -7,12 +7,12 @@ namespace HomeLabManager.API.Services.Scraping.Providers
 {
     public class FakeSerialLookupProvider : IHardwareLookupProvider
     {
-        public bool CanHandle(string codeType)
+        public bool CanHandle(string codeType, string? vendor = null)
         {
             return string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase);
         }
 
-        public Task<ScrapeResult> SearchAsync(string query)
+        public Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
         {
             if(string.Equals(query, "MXQ2160G6X", StringComparison.OrdinalIgnoreCase))
             {

--- a/HomeLabManager.API/Services/Scraping/Providers/UpcLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/UpcLookupProvider.cs
@@ -19,12 +19,12 @@ namespace HomeLabManager.API.Services.Scraping.Providers
             _httpClient = httpClient;
         }
 
-        public bool CanHandle(string codeType)
+        public bool CanHandle(string codeType, string? vendor = null)
         {
             return string.Equals(codeType, "UPC", StringComparison.OrdinalIgnoreCase);
         }
 
-        public async Task<ScrapeResult> SearchAsync(string query)
+        public async Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
         {
             var apiKey = _configuration["UpcDatabase:ApiKey"];
             if (string.IsNullOrWhiteSpace(apiKey))

--- a/HomeLabManager.API/Services/Scraping/ScraperService.cs
+++ b/HomeLabManager.API/Services/Scraping/ScraperService.cs
@@ -15,12 +15,17 @@ namespace HomeLabManager.API.Services.Scraping
         }
         public async Task<ScrapeResult> LookupDeviceAsync(string query, string codeType)
         {
-            foreach (var provider in _providers.Where(provider => provider.CanHandle(codeType)))
+            var detectedVendor = codeType.Equals("SerialNumber", StringComparison.OrdinalIgnoreCase)
+                ? SerialVendorDetector.DetectVendor(query)
+                : string.Empty;
+
+            foreach (var provider in _providers.Where(provider => provider.CanHandle(codeType, detectedVendor)))
             {
-                var result = await provider.SearchAsync(query);
+                var result = await provider.SearchAsync(query, detectedVendor);
 
                 if (result.Success)
                 {
+                    result.DetectedVendor = detectedVendor;
                     return result;
                 }
             }
@@ -28,7 +33,8 @@ namespace HomeLabManager.API.Services.Scraping
             return new ScrapeResult
             {
                 Success = false,
-                Message = "No providers returned a match."
+                Message = "No providers returned a match.",
+                DetectedVendor = detectedVendor
             };
         }
 

--- a/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
+++ b/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
@@ -1,0 +1,27 @@
+namespace HomeLabManager.API.Services.Scraping
+{
+    public static class SerialVendorDetector
+    {
+        public static string DetectVendor(string serial)
+        {
+            if (string.IsNullOrWhiteSpace(serial))
+            {
+                return string.Empty;
+            }
+
+            var normalizedSerial = serial.Trim();
+
+            if (IsLikelyDellServiceTag(normalizedSerial))
+            {
+                return "Dell";
+            }
+
+            return string.Empty;
+        }
+
+        private static bool IsLikelyDellServiceTag(string serial)
+        {
+            return serial.Length == 7 && serial.All(char.IsLetterOrDigit);
+        }
+    }
+}

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -12,5 +12,9 @@
     "AllowedHosts": "*",
     "UpcDatabase":{ 
         "ApiKey":""
+    },
+    "DellSupport":{
+        "Enabled": false,
+        "LookupUrl": ""
     }
 }

--- a/HomeLabManager.Core/Scraping/Models/ScrapeResult.cs
+++ b/HomeLabManager.Core/Scraping/Models/ScrapeResult.cs
@@ -9,6 +9,7 @@ namespace HomeLabManager.Core.Scraping.Models
     {
         public bool Success { get; set; }
         public string Message { get; set; } = string.Empty;
+        public string DetectedVendor { get; set; } = string.Empty;
         public ScrapedDeviceInfo? DeviceInfo { get; set; }
     }
 }


### PR DESCRIPTION
This pull request adds vendor-aware serial number lookup support, specifically introducing Dell serial number lookups, and updates the scraping infrastructure to support vendor detection and extensibility. The main changes include adding a new `DellSerialLookupProvider`, updating the scraping service and interfaces to handle vendor information, and enhancing the API responses to include detected vendor details.

**Vendor-aware lookup and extensibility:**

* Introduced `DellSerialLookupProvider` to support Dell serial number lookups via configurable HTTP API, including robust JSON parsing and error handling. (`HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs`)
* Updated the `IHardwareLookupProvider` interface and all implementing providers to accept and utilize an optional `vendor` parameter in `CanHandle` and `SearchAsync` methods, enabling vendor-specific logic. (`HomeLabManager.API/Services/Scraping/Interfaces/IHardwareLookupProvider.cs`, `FakeHardwareLookupProvider.cs`, `FakeSerialLookupProvider.cs`, `UpcLookupProvider.cs`) [[1]](diffhunk://#diff-ac6a522aa996404ce345181790a52652d523856bcc2df8c1abb6431a4d55e044L7-R8) [[2]](diffhunk://#diff-30d062e54f92cd42b91b733cdc4f34500e75342b8e0089f1fe1d62bb89fc24c4L10-R15) [[3]](diffhunk://#diff-da4a770c0d63993fd9e2d387cde85409fe7ce548ede1d152567a64e813c958b7L10-R15) [[4]](diffhunk://#diff-4d526188669e55e9f9134671b33276662fb2789591109d2787a515a5af1a18b7L22-R27)

**Vendor detection and lookup routing:**

* Added `SerialVendorDetector` utility to detect vendor (currently supports Dell) from serial numbers, and updated `ScraperService` to use detected vendor when selecting lookup providers and to return the vendor in results. (`HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs`, `HomeLabManager.API/Services/Scraping/ScraperService.cs`) [[1]](diffhunk://#diff-a685cbe811cb47f31f63ab683c8051af2da545c82b626bb0f75299c0982d0a69R1-R27) [[2]](diffhunk://#diff-d69d09e0d6c61d81a92037fb291fdb6ed72978514114c3dc93fb06f82e45a6a3L18-R37)
* Registered `DellSerialLookupProvider` in the dependency injection container and added configuration options for Dell support in `appsettings.json`. (`HomeLabManager.API/Program.cs`, `HomeLabManager.API/appsettings.json`) [[1]](diffhunk://#diff-0f4f11d5f0b93efcf632c2d37bbd78cfb0beac90bfb3a8d37b550b142e7abb9eR50-R53) [[2]](diffhunk://#diff-4bff5998da1c06874ff118868533df30ca914e9684361a7ced189cdfc26a4b68R15-R18)

**API and model enhancements:**

* Updated scraping API endpoints and models to include `DetectedVendor` in both request processing and response payloads, ensuring frontend visibility of vendor detection results. (`HomeLabManager.API/Controllers/ScraperController.cs`, `HomeLabManager.API/Models/ImageScrapePreviewResponse.cs`, `HomeLabManager.Core/Scraping/Models/ScrapeResult.cs`) [[1]](diffhunk://#diff-60a6b8a084a8466018571cd42163cef2dbfb41fb46b103d9e11432d1367ed891L27-R28) [[2]](diffhunk://#diff-60a6b8a084a8466018571cd42163cef2dbfb41fb46b103d9e11432d1367ed891R76) [[3]](diffhunk://#diff-0c6e175eea9bb4b5d16d0cf203c920bf7142c771f269fd433bd695f003b00eacR13) [[4]](diffhunk://#diff-a5e2502521948eb1c108d19c145a886dc903417dd0f68f28d8139c58baba5365R12)
* Improved search query analysis to distinguish between UPC and serial number lookups. (`HomeLabManager.API/Controllers/ScraperController.cs`)