### PR TITLE
Feature/25 cisco serial provider integration

### DIFF
--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -52,6 +52,7 @@ namespace HomeLabManager.API
             builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, FakeCiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, CiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
             

--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -48,9 +48,11 @@ namespace HomeLabManager.API
             //Hardware lookup providers - this is where we can add multiple providers and the scraper service will use them in order until it finds a match
             builder.Services.AddHttpClient<UpcLookupProvider>();
             builder.Services.AddHttpClient<DellSerialLookupProvider>();
+            builder.Services.AddHttpClient<CiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, CiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
             
             //ComponentRespositoryInterface, ComponentRepository: Maps interface to implementation

--- a/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
@@ -1,0 +1,306 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    public class CiscoSerialLookupProvider : IHardwareLookupProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly HttpClient _httpClient;
+
+        public CiscoSerialLookupProvider(IConfiguration configuration, HttpClient httpClient)
+        {
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }
+
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            if (!string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.Equals(vendor, "Cisco", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Serial number cannot be empty.",
+                    LookupStatus = "failed_validation"
+                };
+            }
+
+            var isEnabled = _configuration.GetValue<bool?>("CiscoSupport:Enabled") ?? false;
+            if (!isEnabled)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Cisco serial lookup is not enabled in configuration.",
+                    LookupStatus = "not_enabled"
+                };
+            }
+
+            var lookupUrl = _configuration["CiscoSupport:LookupUrl"];
+            if (string.IsNullOrWhiteSpace(lookupUrl))
+            {
+                lookupUrl = "https://sn2info.cisco.com/serial/{serial}";
+            }
+
+            var requestUrl = BuildLookupUrl(lookupUrl, query);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36");
+            request.Headers.AcceptLanguage.ParseAdd("en-US,en;q=0.9");
+            request.Headers.Referrer = new Uri("https://www.cisco.com/");
+
+            var apiKeyHeader = _configuration["CiscoSupport:ApiKeyHeader"];
+            var apiKey = _configuration["CiscoSupport:ApiKey"];
+            if (!string.IsNullOrWhiteSpace(apiKeyHeader) && !string.IsNullOrWhiteSpace(apiKey))
+            {
+                request.Headers.TryAddWithoutValidation(apiKeyHeader, apiKey);
+            }
+
+            var response = await _httpClient.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
+            {
+                var statusCode = (int)response.StatusCode;
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Cisco lookup request failed with status code {statusCode}.",
+                    LookupStatus = response.StatusCode switch
+                    {
+                        HttpStatusCode.Unauthorized => "auth_required",
+                        HttpStatusCode.Forbidden => "auth_required",
+                        HttpStatusCode.TooManyRequests => "rate_limited",
+                        HttpStatusCode.NotFound => "not_found",
+                        _ => "failed_http"
+                    },
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync();
+            if (string.IsNullOrWhiteSpace(responseBody))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Cisco lookup returned an empty response.",
+                    LookupStatus = "empty",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+
+            var html = WebUtility.HtmlDecode(responseBody);
+            var title = ExtractMetaContent(html, "property", "og:title");
+            var description = ExtractMetaContent(html, "name", "description");
+            var canonicalUrl = ExtractLinkHref(html, "canonical");
+
+            if (string.IsNullOrWhiteSpace(title))
+            {
+                title = ExtractTitle(html);
+            }
+
+            var structuredData = ExtractJsonLdDocuments(html);
+            foreach (var document in structuredData)
+            {
+                var root = document.RootElement;
+                title = FirstNonEmpty(title, ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title"));
+                description = FirstNonEmpty(description, ReadString(root, "description", "Description"));
+                canonicalUrl = FirstNonEmpty(canonicalUrl, ReadString(root, "url", "Url", "sourceUrl", "SourceUrl"));
+
+                var manufacturer = FirstNonEmpty(
+                    ReadString(root, "manufacturer", "Manufacturer", "brand", "Brand", "vendor", "Vendor"),
+                    "Cisco");
+                var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model", "sku", "Sku");
+                var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image", "thumbnailUrl", "ThumbnailUrl");
+
+                if (string.IsNullOrWhiteSpace(title)
+                    && string.IsNullOrWhiteSpace(modelNumber)
+                    && string.IsNullOrWhiteSpace(description))
+                {
+                    continue;
+                }
+
+                return new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Cisco serial lookup parsed successfully.",
+                    LookupStatus = "success",
+                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = title,
+                        Manufacturer = manufacturer,
+                        ModelNumber = modelNumber,
+                        SerialNumber = query,
+                        Description = description,
+                        ImageUrl = imageUrl,
+                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? response.RequestMessage?.RequestUri?.ToString() ?? requestUrl : canonicalUrl,
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                };
+            }
+
+            if (responseBody.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("no records", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("invalid serial", StringComparison.OrdinalIgnoreCase))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Cisco lookup did not find a matching serial number.",
+                    LookupStatus = "not_found",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+
+            return new ScrapeResult
+            {
+                Success = false,
+                Message = "Cisco lookup response did not contain recognized product information.",
+                LookupStatus = "not_found",
+                SuggestedLookupUrl = requestUrl
+            };
+        }
+
+        private static string BuildLookupUrl(string lookupUrl, string serial)
+        {
+            if (lookupUrl.Contains("{serial}", StringComparison.OrdinalIgnoreCase))
+            {
+                return lookupUrl.Replace("{serial}", Uri.EscapeDataString(serial), StringComparison.OrdinalIgnoreCase);
+            }
+
+            var separator = lookupUrl.Contains('?') ? "&" : "?";
+            return $"{lookupUrl}{separator}serial={Uri.EscapeDataString(serial)}";
+        }
+
+        private static string ExtractTitle(string html)
+        {
+            var match = Regex.Match(html, @"<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            return match.Success ? WebUtility.HtmlDecode(match.Groups[1].Value).Trim() : string.Empty;
+        }
+
+        private static string ExtractMetaContent(string html, string attributeName, string attributeValue)
+        {
+            var pattern = $"<meta[^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*content\\s*=\\s*[\"'](?<content>.*?)[\"'][^>]*>|<meta[^>]*content\\s*=\\s*[\"'](?<content2>.*?)[\"'][^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var content = match.Groups["content"].Success ? match.Groups["content"].Value : match.Groups["content2"].Value;
+            return WebUtility.HtmlDecode(content).Trim();
+        }
+
+        private static string ExtractLinkHref(string html, string relValue)
+        {
+            var pattern = $"<link[^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*href\\s*=\\s*[\"'](?<href>.*?)[\"'][^>]*>|<link[^>]*href\\s*=\\s*[\"'](?<href2>.*?)[\"'][^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var href = match.Groups["href"].Success ? match.Groups["href"].Value : match.Groups["href2"].Value;
+            return WebUtility.HtmlDecode(href).Trim();
+        }
+
+        private static IEnumerable<JsonDocument> ExtractJsonLdDocuments(string html)
+        {
+            var documents = new List<JsonDocument>();
+            var matches = Regex.Matches(html, "<script[^>]*type=[\"']application/ld\\+json[\"'][^>]*>(?<json>.*?)</script>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            foreach (Match match in matches)
+            {
+                var jsonText = WebUtility.HtmlDecode(match.Groups["json"].Value).Trim();
+                if (string.IsNullOrWhiteSpace(jsonText))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    documents.Add(JsonDocument.Parse(jsonText));
+                }
+                catch (JsonException)
+                {
+                    continue;
+                }
+            }
+
+            return documents;
+        }
+
+        private static string FirstNonEmpty(params string[] values)
+        {
+            return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+        }
+
+        private static string ReadString(JsonElement root, params string[] propertyNames)
+        {
+            foreach (var propertyName in propertyNames)
+            {
+                if (TryReadProperty(root, propertyName, out var value))
+                {
+                    return value;
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static bool TryReadProperty(JsonElement element, string propertyName, out string value)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                foreach (var property in element.EnumerateObject())
+                {
+                    if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        value = property.Value.ValueKind == JsonValueKind.String
+                            ? property.Value.GetString() ?? string.Empty
+                            : property.Value.ToString();
+                        return true;
+                    }
+
+                    if (TryReadProperty(property.Value, propertyName, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var child in element.EnumerateArray())
+                {
+                    if (TryReadProperty(child, propertyName, out value))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            value = string.Empty;
+            return false;
+        }
+    }
+}

--- a/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
@@ -75,109 +75,142 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 request.Headers.TryAddWithoutValidation(apiKeyHeader, apiKey);
             }
 
-            var response = await _httpClient.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
+            try
             {
-                var statusCode = (int)response.StatusCode;
-                return new ScrapeResult
+                var response = await _httpClient.SendAsync(request);
+                if (!response.IsSuccessStatusCode)
                 {
-                    Success = false,
-                    Message = $"Cisco lookup request failed with status code {statusCode}.",
-                    LookupStatus = response.StatusCode switch
+                    var statusCode = (int)response.StatusCode;
+                    return new ScrapeResult
                     {
-                        HttpStatusCode.Unauthorized => "auth_required",
-                        HttpStatusCode.Forbidden => "auth_required",
-                        HttpStatusCode.TooManyRequests => "rate_limited",
-                        HttpStatusCode.NotFound => "not_found",
-                        _ => "failed_http"
-                    },
-                    SuggestedLookupUrl = requestUrl
-                };
-            }
+                        Success = false,
+                        Message = $"Cisco lookup request failed with status code {statusCode}.",
+                        LookupStatus = response.StatusCode switch
+                        {
+                            HttpStatusCode.Unauthorized => "auth_required",
+                            HttpStatusCode.Forbidden => "auth_required",
+                            HttpStatusCode.TooManyRequests => "rate_limited",
+                            HttpStatusCode.NotFound => "not_found",
+                            _ => "failed_http"
+                        },
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
 
-            var responseBody = await response.Content.ReadAsStringAsync();
-            if (string.IsNullOrWhiteSpace(responseBody))
-            {
-                return new ScrapeResult
+                var responseBody = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(responseBody))
                 {
-                    Success = false,
-                    Message = "Cisco lookup returned an empty response.",
-                    LookupStatus = "empty",
-                    SuggestedLookupUrl = requestUrl
-                };
-            }
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Cisco lookup returned an empty response.",
+                        LookupStatus = "empty",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
 
-            var html = WebUtility.HtmlDecode(responseBody);
-            var title = ExtractMetaContent(html, "property", "og:title");
-            var description = ExtractMetaContent(html, "name", "description");
-            var canonicalUrl = ExtractLinkHref(html, "canonical");
+                var html = WebUtility.HtmlDecode(responseBody);
+                var title = ExtractMetaContent(html, "property", "og:title");
+                var description = ExtractMetaContent(html, "name", "description");
+                var canonicalUrl = ExtractLinkHref(html, "canonical");
 
-            if (string.IsNullOrWhiteSpace(title))
-            {
-                title = ExtractTitle(html);
-            }
-
-            var structuredData = ExtractJsonLdDocuments(html);
-            foreach (var document in structuredData)
-            {
-                var root = document.RootElement;
-                title = FirstNonEmpty(title, ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title"));
-                description = FirstNonEmpty(description, ReadString(root, "description", "Description"));
-                canonicalUrl = FirstNonEmpty(canonicalUrl, ReadString(root, "url", "Url", "sourceUrl", "SourceUrl"));
-
-                var manufacturer = FirstNonEmpty(
-                    ReadString(root, "manufacturer", "Manufacturer", "brand", "Brand", "vendor", "Vendor"),
-                    "Cisco");
-                var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model", "sku", "Sku");
-                var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image", "thumbnailUrl", "ThumbnailUrl");
-
-                if (string.IsNullOrWhiteSpace(title)
-                    && string.IsNullOrWhiteSpace(modelNumber)
-                    && string.IsNullOrWhiteSpace(description))
+                if (string.IsNullOrWhiteSpace(title))
                 {
-                    continue;
+                    title = ExtractTitle(html);
+                }
+
+                var structuredData = ExtractJsonLdDocuments(html);
+                foreach (var document in structuredData)
+                {
+                    var root = document.RootElement;
+                    title = FirstNonEmpty(title, ReadString(root, "productName", "ProductName", "name", "Name", "title", "Title"));
+                    description = FirstNonEmpty(description, ReadString(root, "description", "Description"));
+                    canonicalUrl = FirstNonEmpty(canonicalUrl, ReadString(root, "url", "Url", "sourceUrl", "SourceUrl"));
+
+                    var manufacturer = FirstNonEmpty(
+                        ReadString(root, "manufacturer", "Manufacturer", "brand", "Brand", "vendor", "Vendor"),
+                        "Cisco");
+                    var modelNumber = ReadString(root, "modelNumber", "ModelNumber", "model", "Model", "sku", "Sku");
+                    var imageUrl = ReadString(root, "imageUrl", "ImageUrl", "image", "Image", "thumbnailUrl", "ThumbnailUrl");
+
+                    if (string.IsNullOrWhiteSpace(title)
+                        && string.IsNullOrWhiteSpace(modelNumber)
+                        && string.IsNullOrWhiteSpace(description))
+                    {
+                        continue;
+                    }
+
+                    return new ScrapeResult
+                    {
+                        Success = true,
+                        Message = "Cisco serial lookup parsed successfully.",
+                        LookupStatus = "success",
+                        SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
+                        DeviceInfo = new ScrapedDeviceInfo
+                        {
+                            ProductName = title,
+                            Manufacturer = manufacturer,
+                            ModelNumber = modelNumber,
+                            SerialNumber = query,
+                            Description = description,
+                            ImageUrl = imageUrl,
+                            SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? response.RequestMessage?.RequestUri?.ToString() ?? requestUrl : canonicalUrl,
+                            SourceType = ScrapeSourceType.VendorWebsite
+                        }
+                    };
+                }
+
+                if (responseBody.Contains("not found", StringComparison.OrdinalIgnoreCase)
+                    || responseBody.Contains("no records", StringComparison.OrdinalIgnoreCase)
+                    || responseBody.Contains("invalid serial", StringComparison.OrdinalIgnoreCase))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Cisco lookup did not find a matching serial number.",
+                        LookupStatus = "not_found",
+                        SuggestedLookupUrl = requestUrl
+                    };
                 }
 
                 return new ScrapeResult
                 {
-                    Success = true,
-                    Message = "Cisco serial lookup parsed successfully.",
-                    LookupStatus = "success",
-                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
-                    DeviceInfo = new ScrapedDeviceInfo
-                    {
-                        ProductName = title,
-                        Manufacturer = manufacturer,
-                        ModelNumber = modelNumber,
-                        SerialNumber = query,
-                        Description = description,
-                        ImageUrl = imageUrl,
-                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? response.RequestMessage?.RequestUri?.ToString() ?? requestUrl : canonicalUrl,
-                        SourceType = ScrapeSourceType.VendorWebsite
-                    }
-                };
-            }
-
-            if (responseBody.Contains("not found", StringComparison.OrdinalIgnoreCase)
-                || responseBody.Contains("no records", StringComparison.OrdinalIgnoreCase)
-                || responseBody.Contains("invalid serial", StringComparison.OrdinalIgnoreCase))
-            {
-                return new ScrapeResult
-                {
                     Success = false,
-                    Message = "Cisco lookup did not find a matching serial number.",
+                    Message = "Cisco lookup response did not contain recognized product information.",
                     LookupStatus = "not_found",
                     SuggestedLookupUrl = requestUrl
                 };
             }
-
-            return new ScrapeResult
+            catch (HttpRequestException ex)
             {
-                Success = false,
-                Message = "Cisco lookup response did not contain recognized product information.",
-                LookupStatus = "not_found",
-                SuggestedLookupUrl = requestUrl
-            };
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Cisco lookup endpoint unreachable: {ex.Message}",
+                    LookupStatus = "connection_error",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Cisco lookup request timed out.",
+                    LookupStatus = "timeout",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (Exception ex)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Cisco lookup failed with error: {ex.Message}",
+                    LookupStatus = "error",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
         }
 
         private static string BuildLookupUrl(string lookupUrl, string serial)

--- a/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/CiscoSerialLookupProvider.cs
@@ -57,9 +57,11 @@ namespace HomeLabManager.API.Services.Scraping.Providers
             var lookupUrl = _configuration["CiscoSupport:LookupUrl"];
             if (string.IsNullOrWhiteSpace(lookupUrl))
             {
-                lookupUrl = "https://sn2info.cisco.com/serial/{serial}";
+                lookupUrl = "https://www.cisco.com/c/en/us/support/all-products.html";
             }
 
+            // The support page URL is always the manual fallback link shown to users
+            var supportPageUrl = "https://www.cisco.com/c/en/us/support/all-products.html";
             var requestUrl = BuildLookupUrl(lookupUrl, query);
             var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
@@ -93,7 +95,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                             HttpStatusCode.NotFound => "not_found",
                             _ => "failed_http"
                         },
-                        SuggestedLookupUrl = requestUrl
+                            SuggestedLookupUrl = supportPageUrl
                     };
                 }
 
@@ -105,7 +107,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         Success = false,
                         Message = "Cisco lookup returned an empty response.",
                         LookupStatus = "empty",
-                        SuggestedLookupUrl = requestUrl
+                        SuggestedLookupUrl = supportPageUrl
                     };
                 }
 
@@ -140,6 +142,22 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         continue;
                     }
 
+                    var isGenericSupportLandingPage = title.Contains("All Products - Support and Downloads", StringComparison.OrdinalIgnoreCase)
+                        || description.Contains("Support Category page for All Products", StringComparison.OrdinalIgnoreCase)
+                        || (!string.IsNullOrWhiteSpace(canonicalUrl)
+                            && canonicalUrl.Contains("/support/all-products", StringComparison.OrdinalIgnoreCase));
+
+                    if (isGenericSupportLandingPage)
+                    {
+                        return new ScrapeResult
+                        {
+                            Success = false,
+                            Message = "Cisco did not return a specific product from the serial lookup. Use the Cisco support page to continue manually.",
+                            LookupStatus = "manual_lookup_required",
+                            SuggestedLookupUrl = supportPageUrl
+                        };
+                    }
+
                     return new ScrapeResult
                     {
                         Success = true,
@@ -169,7 +187,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         Success = false,
                         Message = "Cisco lookup did not find a matching serial number.",
                         LookupStatus = "not_found",
-                        SuggestedLookupUrl = requestUrl
+                        SuggestedLookupUrl = supportPageUrl
                     };
                 }
 
@@ -178,7 +196,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Success = false,
                     Message = "Cisco lookup response did not contain recognized product information.",
                     LookupStatus = "not_found",
-                    SuggestedLookupUrl = requestUrl
+                    SuggestedLookupUrl = supportPageUrl
                 };
             }
             catch (HttpRequestException ex)
@@ -188,7 +206,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Success = false,
                     Message = $"Cisco lookup endpoint unreachable: {ex.Message}",
                     LookupStatus = "connection_error",
-                    SuggestedLookupUrl = requestUrl
+                    SuggestedLookupUrl = supportPageUrl
                 };
             }
             catch (OperationCanceledException)
@@ -198,7 +216,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Success = false,
                     Message = "Cisco lookup request timed out.",
                     LookupStatus = "timeout",
-                    SuggestedLookupUrl = requestUrl
+                    SuggestedLookupUrl = supportPageUrl
                 };
             }
             catch (Exception ex)
@@ -208,7 +226,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Success = false,
                     Message = $"Cisco lookup failed with error: {ex.Message}",
                     LookupStatus = "error",
-                    SuggestedLookupUrl = requestUrl
+                    SuggestedLookupUrl = supportPageUrl
                 };
             }
         }

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
@@ -1,0 +1,73 @@
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    public class FakeCiscoSerialLookupProvider : IHardwareLookupProvider
+    {
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            return string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(vendor, "Cisco", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            // Example Cisco serial numbers for testing
+            // Format: 3 letters + 8 digits (e.g., FCW2621A40F)
+            if (string.Equals(query, "FCW2621A40F", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Fake Cisco provider found a match.",
+                    LookupStatus = "success",
+                    DetectedVendor = "Cisco",
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = "Catalyst 2960-X Series Switch",
+                        Manufacturer = "Cisco",
+                        ModelNumber = "WS-C2960X-48TS-L",
+                        SerialNumber = "FCW2621A40F",
+                        Category = "Networking",
+                        Description = "Cisco Catalyst 2960-X 48 Port GigabitEthernet Switch",
+                        SourceUrl = "https://tools.cisco.com/security/center/publicationLookup.x",
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                });
+            }
+
+            if (string.Equals(query, "JAE17260H8Z", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Fake Cisco provider found a match.",
+                    LookupStatus = "success",
+                    DetectedVendor = "Cisco",
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = "Cisco ASR 1002-X Router",
+                        Manufacturer = "Cisco",
+                        ModelNumber = "ASR1002-X",
+                        SerialNumber = "JAE17260H8Z",
+                        Category = "Networking",
+                        Description = "Aggregation Services Router with 10 GbE throughput",
+                        SourceUrl = "https://tools.cisco.com/security/center/publicationLookup.x",
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                });
+            }
+
+            return Task.FromResult(new ScrapeResult
+            {
+                Success = false,
+                Message = "Fake Cisco provider found no match.",
+                LookupStatus = "not_found",
+                DetectedVendor = "Cisco"
+            });
+        }
+    }
+}

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
@@ -25,6 +25,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Message = "Fake Cisco provider found a match.",
                     LookupStatus = "success",
                     DetectedVendor = "Cisco",
+                    SuggestedLookupUrl = "https://www.cisco.com/c/en/us/support/all-products.html",
                     DeviceInfo = new ScrapedDeviceInfo
                     {
                         ProductName = "Catalyst 2960-X Series Switch",
@@ -33,7 +34,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         SerialNumber = "FCW2621A40F",
                         Category = "Networking",
                         Description = "Cisco Catalyst 2960-X 48 Port GigabitEthernet Switch",
-                        SourceUrl = "https://tools.cisco.com/security/center/publicationLookup.x",
+                        SourceUrl = "https://www.cisco.com/c/en/us/support/all-products.html",
                         SourceType = ScrapeSourceType.VendorWebsite
                     }
                 });
@@ -47,6 +48,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Message = "Fake Cisco provider found a match.",
                     LookupStatus = "success",
                     DetectedVendor = "Cisco",
+                    SuggestedLookupUrl = "https://www.cisco.com/c/en/us/support/all-products.html",
                     DeviceInfo = new ScrapedDeviceInfo
                     {
                         ProductName = "Cisco ASR 1002-X Router",
@@ -55,7 +57,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         SerialNumber = "JAE17260H8Z",
                         Category = "Networking",
                         Description = "Aggregation Services Router with 10 GbE throughput",
-                        SourceUrl = "https://tools.cisco.com/security/center/publicationLookup.x",
+                        SourceUrl = "https://www.cisco.com/c/en/us/support/all-products.html",
                         SourceType = ScrapeSourceType.VendorWebsite
                     }
                 });
@@ -66,7 +68,8 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 Success = false,
                 Message = "Fake Cisco provider found no match.",
                 LookupStatus = "not_found",
-                DetectedVendor = "Cisco"
+                DetectedVendor = "Cisco",
+                SuggestedLookupUrl = "https://www.cisco.com/c/en/us/support/all-products.html"
             });
         }
     }

--- a/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
+++ b/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
@@ -16,12 +16,33 @@ namespace HomeLabManager.API.Services.Scraping
                 return "Dell";
             }
 
+            if (IsLikelyCiscoSerialNumber(normalizedSerial))
+            {
+                return "Cisco";
+            }
+
             return string.Empty;
         }
 
         private static bool IsLikelyDellServiceTag(string serial)
         {
             return serial.Length == 7 && serial.All(char.IsLetterOrDigit);
+        }
+
+        private static bool IsLikelyCiscoSerialNumber(string serial)
+        {
+            if (serial.Length != 11 || !serial.All(char.IsLetterOrDigit))
+            {
+                return false;
+            }
+
+            return char.IsLetter(serial[0])
+                && char.IsLetter(serial[1])
+                && char.IsLetter(serial[2])
+                && char.IsDigit(serial[3])
+                && char.IsDigit(serial[4])
+                && char.IsDigit(serial[5])
+                && char.IsDigit(serial[6]);
         }
     }
 }

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -4,7 +4,7 @@
     "LookupUrl": "https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}/overview"
   },
   "CiscoSupport": {
-    "Enabled": false,
+    "Enabled": true,
     "LookupUrl": "https://sn2info.cisco.com/serial/{serial}",
     "ApiKeyHeader": "",
     "ApiKey": ""

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -5,7 +5,7 @@
   },
   "CiscoSupport": {
     "Enabled": true,
-    "LookupUrl": "https://sn2info.cisco.com/serial/{serial}",
+    "LookupUrl": "https://www.cisco.com/c/en/us/support/all-products.html",
     "ApiKeyHeader": "",
     "ApiKey": ""
   },

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -3,6 +3,12 @@
     "Enabled": true,
     "LookupUrl": "https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}/overview"
   },
+  "CiscoSupport": {
+    "Enabled": false,
+    "LookupUrl": "https://sn2info.cisco.com/serial/{serial}",
+    "ApiKeyHeader": "",
+    "ApiKey": ""
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -16,5 +16,11 @@
     "DellSupport":{
         "Enabled": false,
         "LookupUrl": ""
+    },
+    "CiscoSupport":{
+        "Enabled": false,
+        "LookupUrl": "",
+        "ApiKeyHeader": "",
+        "ApiKey": ""
     }
 }

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -19,7 +19,7 @@
     },
     "CiscoSupport":{
         "Enabled": false,
-        "LookupUrl": "",
+        "LookupUrl": "https://www.cisco.com/c/en/us/support/all-products.html",
         "ApiKeyHeader": "",
         "ApiKey": ""
     }

--- a/HomeLabManager.WEBUI/Components/Pages/RegisterImage.razor
+++ b/HomeLabManager.WEBUI/Components/Pages/RegisterImage.razor
@@ -144,11 +144,11 @@
                         </div>
                     }
 
-                    @if (IsVendorBlocked(previewResult))
+                    @if (ShouldShowManualLookupLink(previewResult))
                     {
                         <div class="col-12">
                             <a class="btn btn-sm btn-outline-warning" href="@previewResult.SupportLookupUrl" target="_blank">
-                                Open Dell Support Page
+                                @GetManualLookupButtonText(previewResult)
                             </a>
                         </div>
                     }
@@ -273,8 +273,8 @@
             PopulateReviewModelFromPreview();
             statusMessage = lookupResult.Success
                 ? "Lookup completed successfully. Review values before saving."
-                : lookupResult.LookupStatus == "blocked"
-                    ? "Vendor blocked automated lookup. Use the Dell support link below to continue manually."
+                : lookupResult.LookupStatus == "blocked" || lookupResult.LookupStatus == "manual_lookup_required"
+                    ? "Automated lookup could not get a specific product. Use the vendor support link below to continue manually."
                     : "Lookup completed but did not return device information.";
             isError = !lookupResult.Success;
         }
@@ -495,11 +495,32 @@
         };
     }
 
-    private static bool IsVendorBlocked(ImageScrapePreviewResponse result)
+    private static bool ShouldShowManualLookupLink(ImageScrapePreviewResponse result)
     {
-        return string.Equals(result.LookupStatus, "blocked", StringComparison.OrdinalIgnoreCase)
-            && string.Equals(result.DetectedVendor, "Dell", StringComparison.OrdinalIgnoreCase)
-            && !string.IsNullOrWhiteSpace(result.SupportLookupUrl);
+        // Show manual lookup link when automatic lookup fails or is blocked
+        if (string.IsNullOrWhiteSpace(result.SupportLookupUrl) || string.IsNullOrWhiteSpace(result.DetectedVendor))
+        {
+            return false;
+        }
+
+        var failureStatuses = new[] 
+        { 
+            "blocked",           // Vendor actively blocked the request
+            "manual_lookup_required", // Vendor returned a generic support page
+            "not_found",         // No exact serial match was found
+            "connection_error",  // Can't reach the endpoint
+            "auth_required",     // Auth/permission issues
+            "rate_limited",      // Rate limiting
+            "timeout"            // Request timeout
+        };
+
+        return !result.LookupSucceeded 
+            && failureStatuses.Contains(result.LookupStatus);
+    }
+
+    private static string GetManualLookupButtonText(ImageScrapePreviewResponse result)
+    {
+        return $"Open {result.DetectedVendor} Support Page";
     }
 
     private static string ReadableLookupStatus(string status)
@@ -507,12 +528,19 @@
         return status switch
         {
             "success" => "Success",
-            "blocked" => "Blocked",
+            "blocked" => "Blocked by Vendor",
+            "manual_lookup_required" => "Manual Lookup Required",
             "not_found" => "Not Found",
             "not_supported" => "Not Supported",
             "not_attempted" => "Not Attempted",
             "failed_http" => "HTTP Failure",
             "empty" => "Empty Response",
+            "connection_error" => "Connection Error",
+            "auth_required" => "Authentication Required",
+            "rate_limited" => "Rate Limited",
+            "timeout" => "Request Timeout",
+            "not_enabled" => "Not Enabled",
+            "failed_validation" => "Validation Failed",
             _ => string.IsNullOrWhiteSpace(status) ? "Unknown" : status
         };
     }


### PR DESCRIPTION
This pull request adds support for Cisco serial number lookups in the hardware scraping service, including both real and fake providers for testing, vendor detection logic, and configuration options. It also updates the UI and messaging to handle manual lookup scenarios for Cisco devices, similar to existing Dell support.

**Cisco Serial Number Lookup Support:**

- Added a new `CiscoSerialLookupProvider` implementing `IHardwareLookupProvider` to perform live lookups of Cisco serial numbers, parsing HTML responses and extracting product information, with robust error handling and configuration-driven endpoints.
- Introduced a `FakeCiscoSerialLookupProvider` for testing, returning canned responses for known Cisco serial numbers and simulating lookup failures for others.
- Registered both real and fake Cisco providers in the dependency injection setup in `Program.cs`.
- Added Cisco-specific configuration options (`CiscoSupport`) to both `appsettings.json` and `appsettings.Development.json`, including enablement flags, lookup URLs, and optional API key support. [[1]](diffhunk://#diff-4bff5998da1c06874ff118868533df30ca914e9684361a7ced189cdfc26a4b68R19-R24) [[2]](diffhunk://#diff-5b28ae44d22d6eb88700b476a563576df48139fba38a7012b4815ec5740a2e24R6-R11)

**Vendor Detection and UI Integration:**

- Enhanced the serial vendor detector to recognize Cisco serial numbers based on their typical format, enabling automatic routing to the Cisco provider.
- Updated the registration UI to show a manual lookup link and appropriate messaging when automated Cisco lookups require user intervention, generalizing the handling previously specific to Dell. [[1]](diffhunk://#diff-6852851b6711cef4b917e1b08dcce4605e7e7b5d90ae1339c39c17515061b153L147-R151) [[2]](diffhunk://#diff-6852851b6711cef4b917e1b08dcce4605e7e7b5d90ae1339c39c17515061b153L276-R277)