### PR TITLE
Feature hpe serial provider integration

### DIFF
--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -47,10 +47,13 @@ namespace HomeLabManager.API
       
             //Hardware lookup providers - this is where we can add multiple providers and the scraper service will use them in order until it finds a match
             builder.Services.AddHttpClient<UpcLookupProvider>();
+            builder.Services.AddHttpClient<HpeSerialLookupProvider>();
             builder.Services.AddHttpClient<DellSerialLookupProvider>();
             builder.Services.AddHttpClient<CiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, FakeHpeSerialLookupProvider>();
+            builder.Services.AddScoped<IHardwareLookupProvider, HpeSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, FakeCiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, CiscoSerialLookupProvider>();

--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -44,20 +44,26 @@ namespace HomeLabManager.API
 
             //Scraper service and interface
             builder.Services.AddScoped<IScraperService, ScraperService>();
+
+            var enableFakeProviders = builder.Configuration.GetValue<bool>("Scraping:EnableFakeProviders");
       
             //Hardware lookup providers - this is where we can add multiple providers and the scraper service will use them in order until it finds a match
             builder.Services.AddHttpClient<UpcLookupProvider>();
             builder.Services.AddHttpClient<HpeSerialLookupProvider>();
             builder.Services.AddHttpClient<DellSerialLookupProvider>();
             builder.Services.AddHttpClient<CiscoSerialLookupProvider>();
-            builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
-            builder.Services.AddScoped<IHardwareLookupProvider, FakeHpeSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, HpeSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
-            builder.Services.AddScoped<IHardwareLookupProvider, FakeCiscoSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, CiscoSerialLookupProvider>();
-            builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
+
+            if (enableFakeProviders)
+            {
+                builder.Services.AddScoped<IHardwareLookupProvider, FakeHardwareLookupProvider>();
+                builder.Services.AddScoped<IHardwareLookupProvider, FakeHpeSerialLookupProvider>();
+                builder.Services.AddScoped<IHardwareLookupProvider, FakeCiscoSerialLookupProvider>();
+                builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
+            }
             
             //ComponentRespositoryInterface, ComponentRepository: Maps interface to implementation
             builder.Services.AddScoped<ComponentRepositoryInterface, ComponentRepository>();

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeCiscoSerialLookupProvider.cs
@@ -68,8 +68,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 Success = false,
                 Message = "Fake Cisco provider found no match.",
                 LookupStatus = "not_found",
-                DetectedVendor = "Cisco",
-                SuggestedLookupUrl = "https://www.cisco.com/c/en/us/support/all-products.html"
+                DetectedVendor = "Cisco"
             });
         }
     }

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeHpeSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeHpeSerialLookupProvider.cs
@@ -1,0 +1,75 @@
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    public class FakeHpeSerialLookupProvider : IHardwareLookupProvider
+    {
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            return string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase)
+                && (string.IsNullOrWhiteSpace(vendor)
+                    || string.Equals(vendor, "HPE", StringComparison.OrdinalIgnoreCase)
+                    || string.Equals(vendor, "HP", StringComparison.OrdinalIgnoreCase));
+        }
+
+        public Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            if (string.Equals(query, "CN1234A1BC", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Fake HPE provider found a match.",
+                    LookupStatus = "success",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText=CN1234A1BC",
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = "HPE ProLiant DL360 Gen10",
+                        Manufacturer = "HPE",
+                        ModelNumber = "DL360 Gen10",
+                        SerialNumber = "CN1234A1BC",
+                        Category = "Servers",
+                        Description = "HPE ProLiant rack server used for deterministic provider testing.",
+                        SourceUrl = "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText=CN1234A1BC",
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                });
+            }
+
+            if (string.Equals(query, "SGH9876XYZ", StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.FromResult(new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Fake HPE provider found a match.",
+                    LookupStatus = "success",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText=SGH9876XYZ",
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = "HPE Aruba 2930F Switch",
+                        Manufacturer = "HPE",
+                        ModelNumber = "JL256A",
+                        SerialNumber = "SGH9876XYZ",
+                        Category = "Networking",
+                        Description = "HPE Aruba switch used for deterministic provider testing.",
+                        SourceUrl = "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText=SGH9876XYZ",
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                });
+            }
+
+            return Task.FromResult(new ScrapeResult
+            {
+                Success = false,
+                Message = "Fake HPE provider found no match.",
+                LookupStatus = "not_found",
+                DetectedVendor = "HPE"
+            });
+        }
+    }
+}

--- a/HomeLabManager.API/Services/Scraping/Providers/FakeSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/FakeSerialLookupProvider.cs
@@ -15,7 +15,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
 
         public Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
         {
-            if(string.Equals(query, "MXQ2160G6X", StringComparison.OrdinalIgnoreCase))
+            if(string.Equals(query, "TEST-SERIAL-001", StringComparison.OrdinalIgnoreCase))
             {
                 return Task.FromResult(new ScrapeResult
                 {
@@ -26,7 +26,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                         ProductName = "Test Router",
                         Manufacturer = "FakeVendor",
                         ModelNumber = "FAKE-1000",
-                        SerialNumber = "MXQ2160G6X",
+                        SerialNumber = "TEST-SERIAL-001",
                         UPC = "123456789012",
                         Category = "Networking",
                         Description = "Fake test device returned by the fake provider.",

--- a/HomeLabManager.API/Services/Scraping/Providers/HpeSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/HpeSerialLookupProvider.cs
@@ -1,0 +1,314 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.RegularExpressions;
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    public class HpeSerialLookupProvider : IHardwareLookupProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly HttpClient _httpClient;
+
+        public HpeSerialLookupProvider(IConfiguration configuration, HttpClient httpClient)
+        {
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }
+
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            if (!string.Equals(codeType, "SerialNumber", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return string.IsNullOrWhiteSpace(vendor)
+                || string.Equals(vendor, "HPE", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(vendor, "HP", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public async Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Serial number cannot be empty.",
+                    LookupStatus = "failed_validation",
+                    DetectedVendor = "HPE"
+                };
+            }
+
+            var isEnabled = _configuration.GetValue<bool?>("HpeSupport:Enabled") ?? false;
+            if (!isEnabled)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "HPE serial lookup is not enabled in configuration.",
+                    LookupStatus = "not_enabled",
+                    DetectedVendor = "HPE"
+                };
+            }
+
+            var lookupUrl = _configuration["HpeSupport:LookupUrl"];
+            if (string.IsNullOrWhiteSpace(lookupUrl))
+            {
+                lookupUrl = "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText={serial}";
+            }
+
+            var requestUrl = BuildLookupUrl(lookupUrl, query);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36");
+            request.Headers.AcceptLanguage.ParseAdd("en-US,en;q=0.9");
+            request.Headers.Referrer = new Uri("https://partsurfer.hpe.com/Search.aspx");
+
+            try
+            {
+                var response = await _httpClient.SendAsync(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    var statusCode = (int)response.StatusCode;
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = $"HPE PartSurfer request failed with status code {statusCode}.",
+                        LookupStatus = response.StatusCode switch
+                        {
+                            HttpStatusCode.Unauthorized => "auth_required",
+                            HttpStatusCode.Forbidden => "auth_required",
+                            HttpStatusCode.TooManyRequests => "rate_limited",
+                            HttpStatusCode.NotFound => "not_found",
+                            _ => "failed_http"
+                        },
+                        DetectedVendor = "HPE",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(responseBody))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "HPE PartSurfer returned an empty response.",
+                        LookupStatus = "empty",
+                        DetectedVendor = "HPE",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                var html = WebUtility.HtmlDecode(responseBody);
+
+                if (ContainsNoDataMarker(html))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "HPE PartSurfer did not find a matching part or serial number.",
+                        LookupStatus = "not_found",
+                        DetectedVendor = "HPE",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                if (ContainsCountrySelectionPrompt(html))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "HPE PartSurfer needs a country or region selection before it can continue.",
+                        LookupStatus = "manual_lookup_required",
+                        DetectedVendor = "HPE",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                var title = ExtractTitle(html);
+                var description = ExtractMetaContent(html, "name", "description");
+                var canonicalUrl = ExtractLinkHref(html, "canonical");
+
+                var productName = FirstNonEmpty(
+                    ExtractLabeledValue(html, "Product Name"),
+                    ExtractLabeledValue(html, "Product"),
+                    title);
+
+                var modelNumber = FirstNonEmpty(
+                    ExtractLabeledValue(html, "Product Number"),
+                    ExtractLabeledValue(html, "Spare Part Number"),
+                    ExtractLabeledValue(html, "Part Number"),
+                    ExtractLabeledValue(html, "Model Number"));
+
+                var serialNumber = FirstNonEmpty(
+                    ExtractLabeledValue(html, "Serial Number"),
+                    query);
+
+                var category = FirstNonEmpty(
+                    ExtractLabeledValue(html, "Category"),
+                    ExtractLabeledValue(html, "Product Category"));
+
+                var imageUrl = ExtractLabeledValue(html, "Image") ?? string.Empty;
+
+                if (string.IsNullOrWhiteSpace(productName)
+                    && string.IsNullOrWhiteSpace(modelNumber)
+                    && string.IsNullOrWhiteSpace(description))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "HPE PartSurfer returned a page but no specific product details were extracted.",
+                        LookupStatus = "manual_lookup_required",
+                        DetectedVendor = "HPE",
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                return new ScrapeResult
+                {
+                    Success = true,
+                    Message = "HPE PartSurfer parsed successfully.",
+                    LookupStatus = "success",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = productName,
+                        Manufacturer = "HPE",
+                        ModelNumber = modelNumber,
+                        SerialNumber = serialNumber,
+                        Category = category,
+                        Description = description,
+                        ImageUrl = imageUrl,
+                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
+                };
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"HPE PartSurfer endpoint unreachable: {ex.Message}",
+                    LookupStatus = "connection_error",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "HPE PartSurfer request timed out.",
+                    LookupStatus = "timeout",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (Exception ex)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"HPE PartSurfer lookup failed with error: {ex.Message}",
+                    LookupStatus = "error",
+                    DetectedVendor = "HPE",
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+        }
+
+        private static string BuildLookupUrl(string lookupUrl, string serial)
+        {
+            if (lookupUrl.Contains("{serial}", StringComparison.OrdinalIgnoreCase))
+            {
+                return lookupUrl.Replace("{serial}", Uri.EscapeDataString(serial), StringComparison.OrdinalIgnoreCase);
+            }
+
+            var separator = lookupUrl.Contains('?') ? "&" : "?";
+            return $"{lookupUrl}{separator}SearchText={Uri.EscapeDataString(serial)}";
+        }
+
+        private static bool ContainsNoDataMarker(string html)
+        {
+            return html.Contains("lblNoDataFound", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("not found in PartSurfer", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("no data found", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ContainsCountrySelectionPrompt(string html)
+        {
+            return html.Contains("must first select your country or region", StringComparison.OrdinalIgnoreCase)
+                || html.Contains("select your country or region before accessing data", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string ExtractTitle(string html)
+        {
+            var match = Regex.Match(html, @"<title[^>]*>(.*?)</title>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            return match.Success ? WebUtility.HtmlDecode(match.Groups[1].Value).Trim() : string.Empty;
+        }
+
+        private static string ExtractMetaContent(string html, string attributeName, string attributeValue)
+        {
+            var pattern = $"<meta[^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*content\\s*=\\s*[\"'](?<content>.*?)[\"'][^>]*>|<meta[^>]*content\\s*=\\s*[\"'](?<content2>.*?)[\"'][^>]*{Regex.Escape(attributeName)}\\s*=\\s*[\"']{Regex.Escape(attributeValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var content = match.Groups["content"].Success ? match.Groups["content"].Value : match.Groups["content2"].Value;
+            return WebUtility.HtmlDecode(content).Trim();
+        }
+
+        private static string ExtractLinkHref(string html, string relValue)
+        {
+            var pattern = $"<link[^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*href\\s*=\\s*[\"'](?<href>.*?)[\"'][^>]*>|<link[^>]*href\\s*=\\s*[\"'](?<href2>.*?)[\"'][^>]*rel\\s*=\\s*[\"']{Regex.Escape(relValue)}[\"'][^>]*>";
+            var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+            if (!match.Success)
+            {
+                return string.Empty;
+            }
+
+            var href = match.Groups["href"].Success ? match.Groups["href"].Value : match.Groups["href2"].Value;
+            return WebUtility.HtmlDecode(href).Trim();
+        }
+
+        private static string? ExtractLabeledValue(string html, string label)
+        {
+            var patterns = new[]
+            {
+                $"<td[^>]*>\\s*{Regex.Escape(label)}\\s*</td>\\s*<td[^>]*>(?<value>.*?)</td>",
+                $"<th[^>]*>\\s*{Regex.Escape(label)}\\s*</th>\\s*<td[^>]*>(?<value>.*?)</td>",
+                $"{Regex.Escape(label)}\\s*</[^>]+>\\s*<[^>]+>(?<value>.*?)</",
+                $"{Regex.Escape(label)}\\s*[:：]\\s*(?<value>[^<\\r\\n]+)"
+            };
+
+            foreach (var pattern in patterns)
+            {
+                var match = Regex.Match(html, pattern, RegexOptions.IgnoreCase | RegexOptions.Singleline);
+                if (match.Success)
+                {
+                    return WebUtility.HtmlDecode(match.Groups["value"].Value).Trim();
+                }
+            }
+
+            return null;
+        }
+
+        private static string FirstNonEmpty(params string?[] values)
+        {
+            return values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value)) ?? string.Empty;
+        }
+    }
+}

--- a/HomeLabManager.API/Services/Scraping/ScraperService.cs
+++ b/HomeLabManager.API/Services/Scraping/ScraperService.cs
@@ -27,14 +27,22 @@ namespace HomeLabManager.API.Services.Scraping
 
                 if (result.Success)
                 {
-                    result.DetectedVendor = detectedVendor;
+                    if (string.IsNullOrWhiteSpace(result.DetectedVendor))
+                    {
+                        result.DetectedVendor = detectedVendor;
+                    }
+
                     result.LookupStatus = string.IsNullOrWhiteSpace(result.LookupStatus)
                         ? "success"
                         : result.LookupStatus;
                     return result;
                 }
 
-                lastFailure = result;
+                if (lastFailure == null
+                    || (!string.IsNullOrWhiteSpace(result.SuggestedLookupUrl) && string.IsNullOrWhiteSpace(lastFailure.SuggestedLookupUrl)))
+                {
+                    lastFailure = result;
+                }
             }
 
             if (lastFailure != null)
@@ -45,7 +53,9 @@ namespace HomeLabManager.API.Services.Scraping
                     Message = string.IsNullOrWhiteSpace(lastFailure.Message)
                         ? "No providers returned a match."
                         : lastFailure.Message,
-                    DetectedVendor = detectedVendor,
+                    DetectedVendor = string.IsNullOrWhiteSpace(lastFailure.DetectedVendor)
+                        ? detectedVendor
+                        : lastFailure.DetectedVendor,
                     LookupStatus = string.IsNullOrWhiteSpace(lastFailure.LookupStatus)
                         ? "not_found"
                         : lastFailure.LookupStatus,

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -9,6 +9,10 @@
     "ApiKeyHeader": "",
     "ApiKey": ""
   },
+  "HpeSupport": {
+    "Enabled": true,
+    "LookupUrl": "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText={serial}"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "Scraping": {
+    "EnableFakeProviders": false
+  },
   "DellSupport": {
     "Enabled": true,
     "LookupUrl": "https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}/overview"

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -13,6 +13,9 @@
     "UpcDatabase":{ 
         "ApiKey":""
     },
+    "Scraping": {
+        "EnableFakeProviders": false
+    },
     "DellSupport":{
         "Enabled": false,
         "LookupUrl": ""

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -22,5 +22,9 @@
         "LookupUrl": "https://www.cisco.com/c/en/us/support/all-products.html",
         "ApiKeyHeader": "",
         "ApiKey": ""
+    },
+    "HpeSupport":{
+        "Enabled": false,
+        "LookupUrl": "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText={serial}"
     }
 }


### PR DESCRIPTION
This pull request introduces support for HPE serial number lookups, improves the handling and configuration of fake hardware lookup providers, and enhances the scraping logic for better accuracy and flexibility. The main changes include adding a real `HpeSerialLookupProvider`, a corresponding fake provider for testing, updating provider registration logic to be configurable, and refining the scraping service's result handling.

**HPE Serial Lookup Support**

* Added a new `HpeSerialLookupProvider` that performs real HTTP lookups against HPE PartSurfer, parses HTML responses, and extracts product information. This provider is configurable via `appsettings.json` (`HpeSupport:Enabled` and `HpeSupport:LookupUrl`).
* Registered `HpeSerialLookupProvider` in DI and enabled its HTTP client.
* Added configuration for HPE support to both `appsettings.json` and `appsettings.Development.json`.

**Fake Provider Improvements**

* Added a new `FakeHpeSerialLookupProvider` for deterministic HPE serial number testing, and updated the fake serial provider to use a new test serial number (`TEST-SERIAL-001`). [[1]](diffhunk://#diff-abe66015875b78ded57cb34f97cbb4332d02c9f6aa98ea5c55a2ff68d6116ceaR1-R75) [[2]](diffhunk://#diff-da4a770c0d63993fd9e2d387cde85409fe7ce548ede1d152567a64e813c958b7L18-R18) [[3]](diffhunk://#diff-da4a770c0d63993fd9e2d387cde85409fe7ce548ede1d152567a64e813c958b7L29-R29)
* Updated DI registration to conditionally add fake providers based on the `Scraping:EnableFakeProviders` config value. [[1]](diffhunk://#diff-0f4f11d5f0b93efcf632c2d37bbd78cfb0beac90bfb3a8d37b550b142e7abb9eR48-R66) [[2]](diffhunk://#diff-5b28ae44d22d6eb88700b476a563576df48139fba38a7012b4815ec5740a2e24R2-R4) [[3]](diffhunk://#diff-4bff5998da1c06874ff118868533df30ca914e9684361a7ced189cdfc26a4b68R16-R18)

**Scraping Logic and Result Handling**

* Improved provider selection and result handling in `ScraperService` to ensure the most informative failure result is returned and that `DetectedVendor` is set appropriately. [[1]](diffhunk://#diff-d69d09e0d6c61d81a92037fb291fdb6ed72978514114c3dc93fb06f82e45a6a3R29-R46) [[2]](diffhunk://#diff-d69d09e0d6c61d81a92037fb291fdb6ed72978514114c3dc93fb06f82e45a6a3L48-R58)
* Cleaned up the fake Cisco provider to remove an unused field from its result.

These changes make the scraping service more flexible, robust, and ready for both production and testing scenarios.