### PR TITLE
feat(scraper): add web fallback provider for failed vendor lookups

### DIFF
--- a/HomeLabManager.API/Program.cs
+++ b/HomeLabManager.API/Program.cs
@@ -52,6 +52,7 @@ namespace HomeLabManager.API
             builder.Services.AddHttpClient<HpeSerialLookupProvider>();
             builder.Services.AddHttpClient<DellSerialLookupProvider>();
             builder.Services.AddHttpClient<CiscoSerialLookupProvider>();
+            builder.Services.AddHttpClient<WebSearchFallbackProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, UpcLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, HpeSerialLookupProvider>();
             builder.Services.AddScoped<IHardwareLookupProvider, DellSerialLookupProvider>();
@@ -64,6 +65,9 @@ namespace HomeLabManager.API
                 builder.Services.AddScoped<IHardwareLookupProvider, FakeCiscoSerialLookupProvider>();
                 builder.Services.AddScoped<IHardwareLookupProvider, FakeSerialLookupProvider>();
             }
+
+            // Always keep this provider last so it runs only as a final fallback.
+            builder.Services.AddScoped<IHardwareLookupProvider, WebSearchFallbackProvider>();
             
             //ComponentRespositoryInterface, ComponentRepository: Maps interface to implementation
             builder.Services.AddScoped<ComponentRepositoryInterface, ComponentRepository>();

--- a/HomeLabManager.API/Services/Scraping/Providers/WebSearchFallbackProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/WebSearchFallbackProvider.cs
@@ -223,7 +223,14 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 encoded = encoded[..ampIndex];
             }
 
-            return Uri.UnescapeDataString(encoded);
+            try
+            {
+                return Uri.UnescapeDataString(encoded);
+            }
+            catch (UriFormatException)
+            {
+                return rawUrl;
+            }
         }
 
         private static string CleanupHtmlText(string html)

--- a/HomeLabManager.API/Services/Scraping/Providers/WebSearchFallbackProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/WebSearchFallbackProvider.cs
@@ -1,0 +1,241 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using HomeLabManager.API.Services.Scraping.Interfaces;
+using HomeLabManager.Core.Scraping.DTOs;
+using HomeLabManager.Core.Scraping.Enums;
+using HomeLabManager.Core.Scraping.Models;
+using Microsoft.Extensions.Configuration;
+
+namespace HomeLabManager.API.Services.Scraping.Providers
+{
+    // Last-resort provider that does a best-effort web search when vendor/UPC providers fail.
+    public class WebSearchFallbackProvider : IHardwareLookupProvider
+    {
+        private readonly IConfiguration _configuration;
+        private readonly HttpClient _httpClient;
+
+        public WebSearchFallbackProvider(IConfiguration configuration, HttpClient httpClient)
+        {
+            _configuration = configuration;
+            _httpClient = httpClient;
+        }
+
+        public bool CanHandle(string codeType, string? vendor = null)
+        {
+            return !string.IsNullOrWhiteSpace(codeType);
+        }
+
+        public async Task<ScrapeResult> SearchAsync(string query, string? vendor = null)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Search query cannot be empty.",
+                    LookupStatus = "failed_validation",
+                    DetectedVendor = vendor ?? string.Empty
+                };
+            }
+
+            var isEnabled = _configuration.GetValue<bool?>("WebFallback:Enabled") ?? true;
+            var searchTemplate = _configuration["WebFallback:SearchUrlTemplate"]
+                ?? "https://duckduckgo.com/html/?q={query}";
+
+            if (!isEnabled)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Web fallback lookup is disabled in configuration.",
+                    LookupStatus = "not_enabled",
+                    DetectedVendor = vendor ?? string.Empty,
+                    SuggestedLookupUrl = BuildSearchUrl(searchTemplate, query, vendor)
+                };
+            }
+
+            var requestUrl = BuildSearchUrl(searchTemplate, query, vendor);
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+            request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36");
+            request.Headers.Accept.ParseAdd("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8");
+
+            try
+            {
+                var response = await _httpClient.SendAsync(request);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = $"Web fallback request failed with status code {(int)response.StatusCode}.",
+                        LookupStatus = "failed_http",
+                        DetectedVendor = vendor ?? string.Empty,
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                var html = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(html))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Web fallback returned an empty response.",
+                        LookupStatus = "empty",
+                        DetectedVendor = vendor ?? string.Empty,
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                var (title, description, sourceUrl) = ExtractTopResult(html);
+                if (string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(description))
+                {
+                    return new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "No useful web search result could be extracted.",
+                        LookupStatus = "manual_lookup_required",
+                        DetectedVendor = vendor ?? string.Empty,
+                        SuggestedLookupUrl = requestUrl
+                    };
+                }
+
+                return new ScrapeResult
+                {
+                    Success = true,
+                    Message = "Web fallback found a possible device match.",
+                    LookupStatus = "web_fallback",
+                    DetectedVendor = vendor ?? string.Empty,
+                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(sourceUrl) ? requestUrl : sourceUrl,
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = title,
+                        Manufacturer = vendor ?? string.Empty,
+                        ModelNumber = query,
+                        Description = description,
+                        SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? requestUrl : sourceUrl,
+                        SourceType = ScrapeSourceType.RetailerWebsite
+                    }
+                };
+            }
+            catch (HttpRequestException ex)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Web fallback endpoint unreachable: {ex.Message}",
+                    LookupStatus = "connection_error",
+                    DetectedVendor = vendor ?? string.Empty,
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Web fallback request timed out.",
+                    LookupStatus = "timeout",
+                    DetectedVendor = vendor ?? string.Empty,
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+            catch (Exception ex)
+            {
+                return new ScrapeResult
+                {
+                    Success = false,
+                    Message = $"Web fallback lookup failed: {ex.Message}",
+                    LookupStatus = "error",
+                    DetectedVendor = vendor ?? string.Empty,
+                    SuggestedLookupUrl = requestUrl
+                };
+            }
+        }
+
+        private static string BuildSearchUrl(string template, string query, string? vendor)
+        {
+            var searchText = string.IsNullOrWhiteSpace(vendor)
+                ? $"{query} device model specifications"
+                : $"{vendor} {query} device model specifications";
+
+            return template.Replace("{query}", Uri.EscapeDataString(searchText), StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static (string title, string description, string sourceUrl) ExtractTopResult(string html)
+        {
+            var title = string.Empty;
+            var description = string.Empty;
+            var sourceUrl = string.Empty;
+
+            var titleMatch = Regex.Match(
+                html,
+                "<a[^>]*class=\"result__a\"[^>]*href=\"(?<href>[^\"]+)\"[^>]*>(?<title>.*?)</a>",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            if (titleMatch.Success)
+            {
+                sourceUrl = NormalizeSearchResultUrl(WebUtility.HtmlDecode(titleMatch.Groups["href"].Value));
+                title = CleanupHtmlText(titleMatch.Groups["title"].Value);
+            }
+
+            var snippetMatch = Regex.Match(
+                html,
+                "<(a|div)[^>]*class=\"result__snippet\"[^>]*>(?<snippet>.*?)</(a|div)>",
+                RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+            if (snippetMatch.Success)
+            {
+                description = CleanupHtmlText(snippetMatch.Groups["snippet"].Value);
+            }
+
+            return (title, description, sourceUrl);
+        }
+
+        private static string NormalizeSearchResultUrl(string rawUrl)
+        {
+            if (string.IsNullOrWhiteSpace(rawUrl))
+            {
+                return string.Empty;
+            }
+
+            if (rawUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || rawUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                return rawUrl;
+            }
+
+            if (!rawUrl.Contains("uddg=", StringComparison.OrdinalIgnoreCase))
+            {
+                return rawUrl;
+            }
+
+            var marker = rawUrl.IndexOf("uddg=", StringComparison.OrdinalIgnoreCase);
+            if (marker < 0)
+            {
+                return rawUrl;
+            }
+
+            var encoded = rawUrl[(marker + 5)..];
+            var ampIndex = encoded.IndexOf('&');
+            if (ampIndex >= 0)
+            {
+                encoded = encoded[..ampIndex];
+            }
+
+            return Uri.UnescapeDataString(encoded);
+        }
+
+        private static string CleanupHtmlText(string html)
+        {
+            if (string.IsNullOrWhiteSpace(html))
+            {
+                return string.Empty;
+            }
+
+            var noTags = Regex.Replace(html, "<.*?>", string.Empty, RegexOptions.Singleline);
+            var decoded = WebUtility.HtmlDecode(noTags);
+            return Regex.Replace(decoded, "\\s+", " ").Trim();
+        }
+    }
+}

--- a/HomeLabManager.API/appsettings.Development.json
+++ b/HomeLabManager.API/appsettings.Development.json
@@ -16,6 +16,10 @@
     "Enabled": true,
     "LookupUrl": "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText={serial}"
   },
+  "WebFallback": {
+    "Enabled": true,
+    "SearchUrlTemplate": "https://duckduckgo.com/html/?q={query}"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/HomeLabManager.API/appsettings.json
+++ b/HomeLabManager.API/appsettings.json
@@ -29,5 +29,9 @@
     "HpeSupport":{
         "Enabled": false,
         "LookupUrl": "https://partsurfer.hpe.com/Search.aspx?type=SERIAL&SearchText={serial}"
+    },
+    "WebFallback": {
+        "Enabled": true,
+        "SearchUrlTemplate": "https://duckduckgo.com/html/?q={query}"
     }
 }


### PR DESCRIPTION
This pull request introduces a new web search fallback provider to the hardware lookup pipeline, ensuring that if all other providers fail, a best-effort web search is performed to retrieve device information. The changes include the implementation of the provider, its registration in the dependency injection container, and the addition of related configuration options.

**New Web Search Fallback Provider:**

* Added `WebSearchFallbackProvider` implementing `IHardwareLookupProvider`, which performs a web search (using DuckDuckGo by default) as a last-resort lookup when vendor/UPC providers fail. It parses the top result to extract device information and handles various error scenarios gracefully.

**Dependency Injection and Pipeline Registration:**

* Registered `WebSearchFallbackProvider` as an `HttpClient` and as a scoped `IHardwareLookupProvider` in `Program.cs`, ensuring it is always the last provider in the pipeline. [[1]](diffhunk://#diff-0f4f11d5f0b93efcf632c2d37bbd78cfb0beac90bfb3a8d37b550b142e7abb9eR55) [[2]](diffhunk://#diff-0f4f11d5f0b93efcf632c2d37bbd78cfb0beac90bfb3a8d37b550b142e7abb9eR69-R71)

**Configuration:**

* Added `WebFallback` configuration section with `Enabled` and `SearchUrlTemplate` options to both `appsettings.json` and `appsettings.Development.json`, allowing customization and toggling of the web fallback behavior. [[1]](diffhunk://#diff-5b28ae44d22d6eb88700b476a563576df48139fba38a7012b4815ec5740a2e24R19-R22) [[2]](diffhunk://#diff-4bff5998da1c06874ff118868533df30ca914e9684361a7ced189cdfc26a4b68R32-R35)
* close #23 