### PR TITLE
Implement vendor dedup, vendors UI, and scraper routing fixes

### DIFF
--- a/HomeLabManager.API.Tests/Services/Devices/DeviceServiceVendorDedupTests.cs
+++ b/HomeLabManager.API.Tests/Services/Devices/DeviceServiceVendorDedupTests.cs
@@ -1,0 +1,157 @@
+using HomeLabManager.API.Infrastructure;
+using HomeLabManager.API.Interfaces;
+using HomeLabManager.API.Models;
+using HomeLabManager.API.Services;
+using HomeLabManager.Core.Entities;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace HomeLabManager.API.Tests.Services.Devices
+{
+    // These tests focus specifically on issue #24:
+    // repeated saves should reuse the same vendor row after normalization.
+    public class DeviceServiceVendorDedupTests
+    {
+        private static DeviceService CreateService(
+            ApplicationDBContext dbContext,
+            ScanServiceInterface scanService,
+            VendorLookupInterface vendorLookup)
+        {
+            // Use real repository + in-memory EF context so we validate actual persistence behavior.
+            var deviceRepository = new DeviceRepository(dbContext);
+            return new DeviceService(scanService, vendorLookup, deviceRepository, dbContext);
+        }
+
+        [Fact]
+        public async Task RegisterManualDeviceAsync_ReusesExistingVendor_ForNormalizedName()
+        {
+            // Arrange: seed one canonical vendor row.
+            var options = new DbContextOptionsBuilder<ApplicationDBContext>()
+                .UseInMemoryDatabase($"manual-vendor-dedup-{Guid.NewGuid()}")
+                .Options;
+
+            await using var dbContext = new ApplicationDBContext(options);
+            var existingVendor = new Vendor
+            {
+                Id = Guid.NewGuid(),
+                VendorName = "HPE"
+            };
+            dbContext.Vendors.Add(existingVendor);
+            await dbContext.SaveChangesAsync();
+
+            var service = CreateService(
+                dbContext,
+                new StubScanService(string.Empty),
+                new StubVendorLookup(new Product()));
+
+            var firstRequest = new ManualDeviceRegisterRequest
+            {
+                SerialNumber = "SERIAL-001",
+                NickName = "First",
+                ProductName = "Server One",
+                ModelNumber = "DL360",
+                VendorName = "HPE"
+            };
+
+            var secondRequest = new ManualDeviceRegisterRequest
+            {
+                SerialNumber = "SERIAL-002",
+                NickName = "Second",
+                ProductName = "Server Two",
+                ModelNumber = "DL360",
+                VendorName = "  hpe  "
+            };
+
+            // Act: save two devices with logically same vendor but different formatting.
+            await service.RegisterManualDeviceAsync(firstRequest);
+            await service.RegisterManualDeviceAsync(secondRequest);
+
+            var vendors = await dbContext.Vendors.ToListAsync();
+            var devices = await dbContext.Devices.Include(device => device.Product).ThenInclude(product => product.Vendor).ToListAsync();
+
+            // Assert: only one vendor row exists and both devices reference it.
+            Assert.Single(vendors);
+            Assert.Equal("HPE", vendors[0].VendorName);
+            Assert.Equal(2, devices.Count);
+            Assert.All(devices, device => Assert.Equal(existingVendor.Id, device.Product!.VendorId));
+        }
+
+        [Fact]
+        public async Task RegisterDeviceAsync_ReusesExistingVendor_ForScannedProduct()
+        {
+            // Arrange: existing canonical vendor and a scanned product carrying a padded/lowercase vendor name.
+            var options = new DbContextOptionsBuilder<ApplicationDBContext>()
+                .UseInMemoryDatabase($"scan-vendor-dedup-{Guid.NewGuid()}")
+                .Options;
+
+            await using var dbContext = new ApplicationDBContext(options);
+            var existingVendor = new Vendor
+            {
+                Id = Guid.NewGuid(),
+                VendorName = "Dell"
+            };
+            dbContext.Vendors.Add(existingVendor);
+            await dbContext.SaveChangesAsync();
+
+            var scannedProduct = new Product
+            {
+                Id = Guid.NewGuid(),
+                ProductName = "PowerEdge",
+                ModelNumber = "R640",
+                VendorId = Guid.NewGuid(),
+                Vendor = new Vendor
+                {
+                    Id = Guid.NewGuid(),
+                    VendorName = "  dell  "
+                }
+            };
+
+            var service = CreateService(
+                dbContext,
+                new StubScanService("SERIAL-SCAN-001"),
+                new StubVendorLookup(scannedProduct));
+
+            // Act: run scan registration path.
+            await service.RegisterDeviceAsync(new MemoryStream(new byte[] { 1, 2, 3 }));
+
+            var vendors = await dbContext.Vendors.ToListAsync();
+            var device = await dbContext.Devices.Include(item => item.Product).ThenInclude(product => product.Vendor).SingleAsync();
+
+            // Assert: product points to existing vendor row instead of creating a duplicate vendor.
+            Assert.Single(vendors);
+            Assert.Equal("Dell", vendors[0].VendorName);
+            Assert.Equal(existingVendor.Id, device.Product!.VendorId);
+            Assert.Equal(existingVendor.Id, device.Product.Vendor!.Id);
+        }
+
+        private sealed class StubScanService : ScanServiceInterface
+        {
+            private readonly string _serial;
+
+            public StubScanService(string serial)
+            {
+                _serial = serial;
+            }
+
+            public Task<string> ExtractSerialAsync(ScanRequest request)
+            {
+                return Task.FromResult(_serial);
+            }
+        }
+
+        private sealed class StubVendorLookup : VendorLookupInterface
+        {
+            private readonly Product _product;
+
+            public StubVendorLookup(Product product)
+            {
+                _product = product;
+            }
+
+            public Task<Product> GetProductBySerialAsync(string serial)
+            {
+                return Task.FromResult(_product);
+            }
+        }
+    }
+}

--- a/HomeLabManager.API.Tests/Services/Scraping/ScraperServiceRoutingTests.cs
+++ b/HomeLabManager.API.Tests/Services/Scraping/ScraperServiceRoutingTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 namespace HomeLabManager.API.Tests.Services.Scraping
 {
     /// <summary>
-    /// Test implementations of IHardwareLookupProvider for controlled testing
+    /// Test implementation of IHardwareLookupProvider for controlled routing behavior.
     /// </summary>
     public class TestProvider : IHardwareLookupProvider
     {
@@ -40,15 +40,13 @@ namespace HomeLabManager.API.Tests.Services.Scraping
 
     public class ScraperServiceRoutingTests
     {
-
         [Fact]
         public async Task LookupDeviceAsync_WithDellSerialNumber_RoutesToDellProvider()
         {
-            // Arrange: Dell serial format (7 alphanumeric)
             var dellSerial = "ABC1234";
-            
+
             var dellProvider = new TestProvider(
-                "SerialNumber", 
+                "SerialNumber",
                 "Dell",
                 (serial, vendor) => Task.FromResult(new ScrapeResult
                 {
@@ -62,10 +60,8 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { dellProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(dellSerial, "SerialNumber");
 
-            // Assert
             Assert.True(result.Success);
             Assert.Equal("Dell", result.DetectedVendor);
         }
@@ -73,9 +69,8 @@ namespace HomeLabManager.API.Tests.Services.Scraping
         [Fact]
         public async Task LookupDeviceAsync_WithCiscoSerialNumber_RoutesToCiscoProvider()
         {
-            // Arrange: Cisco serial format (11 chars: 3 letters + 8 digits)
             var ciscoSerial = "ABC12345678";
-            
+
             var ciscoProvider = new TestProvider(
                 "SerialNumber",
                 "Cisco",
@@ -92,32 +87,67 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { ciscoProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(ciscoSerial, "SerialNumber");
 
-            // Assert
             Assert.False(result.Success);
             Assert.Equal("Cisco", result.DetectedVendor);
             Assert.Equal("manual_lookup_required", result.LookupStatus);
         }
 
         [Fact]
+        public async Task LookupDeviceAsync_UnknownVendor_DoesNotStopOnManualLookupRequired()
+        {
+            var unknownSerial = "CISCO2811V07";
+
+            var dellLikeManualProvider = new TestProvider(
+                "SerialNumber",
+                null,
+                (serial, vendor) => Task.FromResult(new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Manual lookup required",
+                    LookupStatus = "manual_lookup_required",
+                    SuggestedLookupUrl = "https://www.dell.com/support"
+                })
+            );
+
+            var fallbackProvider = new TestProvider(
+                "SerialNumber",
+                null,
+                (serial, vendor) => Task.FromResult(new ScrapeResult
+                {
+                    Success = false,
+                    Message = "Not found via fallback",
+                    LookupStatus = "not_found",
+                    SuggestedLookupUrl = "https://fallback.example/search?q=CISCO2811V07"
+                })
+            );
+
+            var providers = new List<IHardwareLookupProvider> { dellLikeManualProvider, fallbackProvider };
+            var service = new ScraperService(providers);
+
+            var result = await service.LookupDeviceAsync(unknownSerial, "SerialNumber");
+
+            Assert.False(result.Success);
+            Assert.Equal("not_found", result.LookupStatus);
+            Assert.NotNull(result.SuggestedLookupUrl);
+            Assert.Contains("fallback.example", result.SuggestedLookupUrl);
+        }
+
+        [Fact]
         public async Task LookupDeviceAsync_WithUnknownSerial_FallsBackToNextProvider()
         {
-            // Arrange: Unknown serial that doesn't match Dell/Cisco format (10 chars)
             var unknownSerial = "MXQ2160G6X";
-            
-            // First provider (e.g., Dell) can't handle unknown serial
+
             var dellProvider = new TestProvider(
                 "SerialNumber",
                 "Dell",
                 (serial, vendor) => Task.FromResult(new ScrapeResult())
             );
 
-            // Second provider (e.g., HPE) handles unknown serials
             var hpeProvider = new TestProvider(
                 "SerialNumber",
-                null,  // handles any vendor (null or otherwise)
+                null,
                 (serial, vendor) => Task.FromResult(new ScrapeResult
                 {
                     Success = false,
@@ -131,22 +161,19 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { dellProvider, hpeProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(unknownSerial, "SerialNumber");
 
-            // Assert
             Assert.False(result.Success);
             Assert.NotNull(result.SuggestedLookupUrl);
-            StringAssert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
+            Assert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_ReturnFirstSuccess()
         {
-            // Arrange: Multiple providers, first one succeeds
             var serialNumber = "ABC1234";
-            
             var callCount = 0;
+
             var firstProvider = new TestProvider(
                 "SerialNumber",
                 "Dell",
@@ -172,20 +199,17 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { firstProvider, secondProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(serialNumber, "SerialNumber");
 
-            // Assert
             Assert.True(result.Success);
-            Assert.Equal(1, callCount); // First provider should only be called once
+            Assert.Equal(1, callCount);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_PreferResultWithSuggestedUrl()
         {
-            // Arrange: Multiple failures, one with manual-lookup URL should win (URL takes priority)
-            var unknownSerial = "XYZ123456789";  // 12 chars, won't match Dell/Cisco
-            
+            var unknownSerial = "XYZ123456789";
+
             var hpeProvider = new TestProvider(
                 "SerialNumber",
                 null,
@@ -208,28 +232,24 @@ namespace HomeLabManager.API.Tests.Services.Scraping
                     Message = "No match",
                     DetectedVendor = "FallbackVendor",
                     LookupStatus = "not_found"
-                    // No SuggestedLookupUrl
                 })
             );
 
             var providers = new List<IHardwareLookupProvider> { hpeProvider, fallbackProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(unknownSerial, "SerialNumber");
 
-            // Assert
             Assert.False(result.Success);
             Assert.NotNull(result.SuggestedLookupUrl);
-            StringAssert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
+            Assert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_WithUpcCode_SkipsSerialProviders()
         {
-            // Arrange: UPC query should only use UPC providers
             var upcCode = "012345678901";
-            
+
             var upcProvider = new TestProvider(
                 "Upc",
                 null,
@@ -250,17 +270,14 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { upcProvider, serialProvider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(upcCode, "Upc");
 
-            // Assert
             Assert.True(result.Success);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_NoProvidersCanHandle_ReturnsNotSupported()
         {
-            // Arrange: No providers support the code type
             var provider = new TestProvider(
                 "UnsupportedType",
                 null,
@@ -270,10 +287,8 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { provider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync("anything", "UnknownType");
 
-            // Assert
             Assert.False(result.Success);
             Assert.Equal("not_supported", result.LookupStatus);
         }
@@ -281,7 +296,6 @@ namespace HomeLabManager.API.Tests.Services.Scraping
         [Fact]
         public async Task LookupDeviceAsync_PreserveProviderDetectedVendor()
         {
-            // Arrange: Provider explicitly sets DetectedVendor, ScraperService should preserve it
             var serial = "ABC1234";
             var provider = new TestProvider(
                 "SerialNumber",
@@ -298,17 +312,14 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { provider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(serial, "SerialNumber");
 
-            // Assert
             Assert.Equal("Dell", result.DetectedVendor);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_FillInDetectedVendorIfMissing()
         {
-            // Arrange: Provider doesn't set DetectedVendor, ScraperService fills it in
             var serial = "ABC1234";
             var provider = new TestProvider(
                 "SerialNumber",
@@ -317,27 +328,22 @@ namespace HomeLabManager.API.Tests.Services.Scraping
                 {
                     Success = true,
                     Message = "Found"
-                    // DetectedVendor is null/empty
                 })
             );
 
             var providers = new List<IHardwareLookupProvider> { provider };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(serial, "SerialNumber");
 
-            // Assert
             Assert.Equal("Dell", result.DetectedVendor);
         }
 
         [Fact]
         public async Task LookupDeviceAsync_MultipleFailures_SelectBestFallback()
         {
-            // Arrange: Three failing providers, prefer the one with manual-lookup URL
-            var unknownSerial = "ABC1234567890";  // 13 chars, won't match Dell/Cisco
-            
-            // Provider 1: Generic failure without URL (will be initial lastFailure)
+            var unknownSerial = "ABC1234567890";
+
             var provider1 = new TestProvider(
                 "SerialNumber",
                 null,
@@ -350,7 +356,6 @@ namespace HomeLabManager.API.Tests.Services.Scraping
                 })
             );
 
-            // Provider 2: Failure with manual-lookup URL (will replace lastFailure)
             var provider2 = new TestProvider(
                 "SerialNumber",
                 null,
@@ -364,7 +369,6 @@ namespace HomeLabManager.API.Tests.Services.Scraping
                 })
             );
 
-            // Provider 3: Another failure without URL (won't replace because provider2 has URL)
             var provider3 = new TestProvider(
                 "SerialNumber",
                 null,
@@ -379,26 +383,12 @@ namespace HomeLabManager.API.Tests.Services.Scraping
             var providers = new List<IHardwareLookupProvider> { provider1, provider2, provider3 };
             var service = new ScraperService(providers);
 
-            // Act
             var result = await service.LookupDeviceAsync(unknownSerial, "SerialNumber");
 
-            // Assert
             Assert.False(result.Success);
             Assert.NotNull(result.SuggestedLookupUrl);
             Assert.Equal("manual_lookup_required", result.LookupStatus);
-            StringAssert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
-        }
-    }
-
-    /// <summary>
-    /// Helper class for string assertions
-    /// </summary>
-    public static class StringAssert
-    {
-        public static void Contains(string expectedSubstring, string? actualString)
-        {
-            Assert.NotNull(actualString);
-            Assert.Contains(expectedSubstring, actualString);
+            Assert.Contains("partsurfer.hpe.com", result.SuggestedLookupUrl);
         }
     }
 }

--- a/HomeLabManager.API.Tests/Services/Scraping/SerialVendorDetectorTests.cs
+++ b/HomeLabManager.API.Tests/Services/Scraping/SerialVendorDetectorTests.cs
@@ -1,0 +1,22 @@
+using HomeLabManager.API.Services.Scraping;
+using Xunit;
+
+namespace HomeLabManager.API.Tests.Services.Scraping
+{
+    public class SerialVendorDetectorTests
+    {
+        [Fact]
+        public void DetectVendor_WithCiscoPrefixedLabel_ReturnsCisco()
+        {
+            var result = SerialVendorDetector.DetectVendor("CISCO2811 V07");
+            Assert.Equal("Cisco", result);
+        }
+
+        [Fact]
+        public void DetectVendor_WithDellServiceTag_ReturnsDell()
+        {
+            var result = SerialVendorDetector.DetectVendor("5d34gt2");
+            Assert.Equal("Dell", result);
+        }
+    }
+}

--- a/HomeLabManager.API/Controllers/VendorsController.cs
+++ b/HomeLabManager.API/Controllers/VendorsController.cs
@@ -1,0 +1,98 @@
+using HomeLabManager.API.Infrastructure;
+using HomeLabManager.API.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace HomeLabManager.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class VendorsController : ControllerBase
+    {
+        private readonly ApplicationDBContext _dbContext;
+        private readonly ILogger<VendorsController> _logger;
+
+        public VendorsController(ApplicationDBContext dbContext, ILogger<VendorsController> logger)
+        {
+            _dbContext = dbContext;
+            _logger = logger;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<List<VendorSummaryResponse>>> GetVendors()
+        {
+            try
+            {
+                // Step 1: count how many products reference each vendor.
+                var productCountsByVendor = await _dbContext.Products
+                    .AsNoTracking()
+                    .GroupBy(product => product.VendorId)
+                    .Select(group => new
+                    {
+                        VendorId = group.Key,
+                        ProductCount = group.Count()
+                    })
+                    .ToDictionaryAsync(item => item.VendorId, item => item.ProductCount);
+
+                // Step 2: count devices and compute "last seen" timestamp for each vendor.
+                // Devices point to Products, and Products point to Vendors, so this is a join.
+                var deviceStatsByVendor = await _dbContext.Devices
+                    .AsNoTracking()
+                    .Join(
+                        _dbContext.Products.AsNoTracking(),
+                        device => device.ProductId,
+                        product => product.Id,
+                        (device, product) => new
+                        {
+                            product.VendorId,
+                            device.CreatedAtUtc
+                        })
+                    .GroupBy(item => item.VendorId)
+                    .Select(group => new
+                    {
+                        VendorId = group.Key,
+                        DeviceCount = group.Count(),
+                        LastSeenUtc = group.Max(item => (DateTime?)item.CreatedAtUtc)
+                    })
+                    .ToDictionaryAsync(
+                        item => item.VendorId,
+                        item => new
+                        {
+                            item.DeviceCount,
+                            item.LastSeenUtc
+                        });
+
+                // Step 3: load the base vendor list and sort for stable UI ordering.
+                var vendors = await _dbContext.Vendors
+                    .AsNoTracking()
+                    .OrderBy(vendor => vendor.VendorName)
+                    .ToListAsync();
+
+                // Step 4: merge all stats into one response per vendor.
+                var response = vendors.Select(vendor =>
+                {
+                    productCountsByVendor.TryGetValue(vendor.Id, out var productCount);
+                    var hasDeviceStats = deviceStatsByVendor.TryGetValue(vendor.Id, out var deviceStats);
+
+                    return new VendorSummaryResponse
+                    {
+                        Id = vendor.Id,
+                        VendorName = vendor.VendorName,
+                        VendorBaseUrl = vendor.VendorBaseUrl,
+                        ProductCount = productCount,
+                        DeviceCount = hasDeviceStats ? deviceStats!.DeviceCount : 0,
+                        LastSeenUtc = hasDeviceStats ? deviceStats!.LastSeenUtc : null
+                    };
+                }).ToList();
+
+                // Return card/table-ready data to the WebUI vendors page.
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "An error occurred while retrieving vendors.");
+                return StatusCode(500, "An error occurred while retrieving vendors.");
+            }
+        }
+    }
+}

--- a/HomeLabManager.API/Models/VendorSummaryResponse.cs
+++ b/HomeLabManager.API/Models/VendorSummaryResponse.cs
@@ -1,0 +1,12 @@
+namespace HomeLabManager.API.Models
+{
+    public class VendorSummaryResponse
+    {
+        public Guid Id { get; set; }
+        public string VendorName { get; set; } = string.Empty;
+        public string? VendorBaseUrl { get; set; }
+        public int ProductCount { get; set; }
+        public int DeviceCount { get; set; }
+        public DateTime? LastSeenUtc { get; set; }
+    }
+}

--- a/HomeLabManager.API/Services/DeviceService.cs
+++ b/HomeLabManager.API/Services/DeviceService.cs
@@ -11,6 +11,7 @@ namespace HomeLabManager.API.Services
 {
     public class DeviceService
     {
+        // This service coordinates scan/manual registration and keeps related entities consistent.
         //initiateing the dependencies for the device service, these are the services that will be used to complete the process of registering a device
         private readonly ScanServiceInterface scanService;
         private readonly VendorLookupInterface vendorLookup;
@@ -66,6 +67,13 @@ namespace HomeLabManager.API.Services
             var product = await vendorLookup.GetProductBySerialAsync(serial);
             // vendor lookup completed
 
+            //reuse an existing vendor when the normalized name already exists
+            var vendor = await GetOrCreateVendorAsync(product.Vendor?.VendorName ?? "Unknown Vendor", product.Vendor?.VendorBaseUrl);
+
+            // Always re-point the product to the canonical vendor row so duplicates are not created.
+            product.VendorId = vendor.Id;
+            product.Vendor = vendor;
+
             //create the actual device
             var device = new Device
             {
@@ -76,11 +84,7 @@ namespace HomeLabManager.API.Services
                 CreatedAtUtc = DateTime.UtcNow
             };
 
-            //explicitly add vendor and product to DbContext to ensure they are tracked
-            if (product.Vendor != null)
-            {
-                dbContext.Vendors.Add(product.Vendor);
-            }
+            //add the new product to DbContext while reusing any existing vendor row
             dbContext.Products.Add(product);
 
             //adds the created device so it can persist
@@ -145,6 +149,35 @@ namespace HomeLabManager.API.Services
             };
         }
 
+        private async Task<Vendor> GetOrCreateVendorAsync(string vendorName, string? vendorBaseUrl = null)
+        {
+            // Normalize values so case and extra spaces don't create duplicate vendor rows.
+            var normalizedVendorName = string.IsNullOrWhiteSpace(vendorName)
+                ? "Unknown Vendor"
+                : vendorName.Trim();
+
+            // Compare vendor names in a case-insensitive way against existing rows.
+            var existingVendor = await dbContext.Vendors.FirstOrDefaultAsync(vendor =>
+                vendor.VendorName.Trim().ToUpper() == normalizedVendorName.ToUpper());
+
+            if (existingVendor != null)
+            {
+                // Reuse the existing vendor so all related products/devices stay connected.
+                return existingVendor;
+            }
+
+            // No match found: create a new canonical vendor row.
+            var vendor = new Vendor
+            {
+                Id = Guid.NewGuid(),
+                VendorName = normalizedVendorName,
+                VendorBaseUrl = vendorBaseUrl
+            };
+
+            await dbContext.Vendors.AddAsync(vendor);
+            return vendor;
+        }
+
         public async Task<DeviceResponseDataTransferObject> RegisterManualDeviceAsync(ManualDeviceRegisterRequest request)
         {
             if (string.IsNullOrWhiteSpace(request.SerialNumber) && string.IsNullOrWhiteSpace(request.NickName))
@@ -157,12 +190,8 @@ namespace HomeLabManager.API.Services
                     throw new DuplicateSerialNumberException("A device with the same serial number already exists.");
             }
 
-            //sets the vendor for the manual entry
-            var vendor = new Vendor
-            {
-                Id = Guid.NewGuid(),
-                VendorName = request.VendorName ?? "ManualEntry"//returns this if left null
-            };
+            //reuse an existing vendor when the normalized name already exists
+            var vendor = await GetOrCreateVendorAsync(request.VendorName ?? "ManualEntry");
 
             //sets the product info for manual entry
             var product = new Product
@@ -170,6 +199,7 @@ namespace HomeLabManager.API.Services
                 Id = Guid.NewGuid(),
                 ProductName = request.ProductName ?? "Unkown Product",//returns this if left null
                 ModelNumber = request.ModelNumber ?? "Unknown Model",
+                // Manual registration also uses the canonical vendor row returned above.
                 VendorId = vendor.Id,
                 Vendor = vendor
             };
@@ -186,8 +216,7 @@ namespace HomeLabManager.API.Services
                 CreatedAtUtc = DateTime.UtcNow
             };
 
-            //explicitly add vendor and product to DbContext to ensure they are tracked
-            dbContext.Vendors.Add(vendor);
+            //add the new product to DbContext while reusing any existing vendor row
             dbContext.Products.Add(product);
 
             //adds the created device so it can persist

--- a/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
+++ b/HomeLabManager.API/Services/Scraping/Providers/DellSerialLookupProvider.cs
@@ -59,7 +59,92 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 lookupUrl = "https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}/overview";
             }
 
-            var requestUrl = BuildLookupUrl(lookupUrl, query);
+            var manualLookupUrl = "https://www.dell.com/support/home/en-us";
+
+            // Try both service-tag page variants because Dell frequently changes route behavior.
+            var candidateUrls = new[]
+            {
+                BuildLookupUrl(lookupUrl, query),
+                BuildLookupUrl("https://www.dell.com/support/home/en-us/product-support/servicetag/{serial}", query)
+            }.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            var lastFailure = new ScrapeResult
+            {
+                Success = false,
+                Message = "Dell lookup did not return a parseable result.",
+                LookupStatus = "not_found",
+                SuggestedLookupUrl = manualLookupUrl
+            };
+
+            foreach (var candidateUrl in candidateUrls)
+            {
+                var request = CreateDellRequest(candidateUrl);
+                var response = await _httpClient.SendAsync(request);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var statusCode = (int)response.StatusCode;
+                    lastFailure = new ScrapeResult
+                    {
+                        Success = false,
+                        Message = response.StatusCode == HttpStatusCode.Forbidden
+                            ? "Dell blocked direct service-tag scraping. Open Dell Support and enter the service tag manually."
+                            : $"Dell lookup request failed with status code {statusCode}.",
+                        LookupStatus = response.StatusCode == HttpStatusCode.Forbidden ? "manual_lookup_required" : "failed_http",
+                        SuggestedLookupUrl = manualLookupUrl
+                    };
+
+                    continue;
+                }
+
+                var responseBody = await response.Content.ReadAsStringAsync();
+                if (string.IsNullOrWhiteSpace(responseBody))
+                {
+                    lastFailure = new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Dell lookup returned an empty response.",
+                        LookupStatus = "empty",
+                        SuggestedLookupUrl = manualLookupUrl
+                    };
+
+                    continue;
+                }
+
+                if (ContainsBlockedMarker(responseBody))
+                {
+                    lastFailure = new ScrapeResult
+                    {
+                        Success = false,
+                        Message = "Dell blocked automated lookup from this endpoint. Open Dell Support and enter the service tag manually.",
+                        LookupStatus = "manual_lookup_required",
+                        SuggestedLookupUrl = manualLookupUrl
+                    };
+
+                    continue;
+                }
+
+                var parsedResult = TryParseDellResponse(responseBody, query, candidateUrl, response.RequestMessage?.RequestUri?.ToString());
+                if (parsedResult.Success)
+                {
+                    return parsedResult;
+                }
+
+                lastFailure = parsedResult;
+            }
+
+            // Final fallback for Dell-specific flow.
+            return new ScrapeResult
+            {
+                Success = false,
+                Message = "Dell did not return parseable product details. Open Dell Support and enter the service tag manually.",
+                LookupStatus = "manual_lookup_required",
+                SuggestedLookupUrl = manualLookupUrl
+            };
+        }
+
+        private static HttpRequestMessage CreateDellRequest(string requestUrl)
+        {
             var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/xhtml+xml"));
@@ -69,31 +154,19 @@ namespace HomeLabManager.API.Services.Scraping.Providers
             request.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36");
             request.Headers.AcceptLanguage.ParseAdd("en-US,en;q=0.9");
             request.Headers.Referrer = new Uri("https://www.dell.com/support/home/en-us");
+            return request;
+        }
 
-            var response = await _httpClient.SendAsync(request);
-            if (!response.IsSuccessStatusCode)
-            {
-                var statusCode = (int)response.StatusCode;
-                return new ScrapeResult
-                {
-                    Success = false,
-                    Message = $"Dell lookup request failed with status code {statusCode}.",
-                    LookupStatus = response.StatusCode == HttpStatusCode.Forbidden ? "blocked" : "failed_http",
-                    SuggestedLookupUrl = requestUrl
-                };
-            }
+        private static bool ContainsBlockedMarker(string responseBody)
+        {
+            return responseBody.Contains("Access Denied", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("errors.edgesuite.net", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("Request blocked", StringComparison.OrdinalIgnoreCase)
+                || responseBody.Contains("akamai", StringComparison.OrdinalIgnoreCase);
+        }
 
-            var responseBody = await response.Content.ReadAsStringAsync();
-            if (string.IsNullOrWhiteSpace(responseBody))
-            {
-                return new ScrapeResult
-                {
-                    Success = false,
-                    Message = "Dell lookup returned an empty response.",
-                    LookupStatus = "empty"
-                };
-            }
-
+        private static ScrapeResult TryParseDellResponse(string responseBody, string serial, string requestedUrl, string? responseUrl)
+        {
             var html = WebUtility.HtmlDecode(responseBody);
             var title = ExtractMetaContent(html, "property", "og:title");
             var description = ExtractMetaContent(html, "name", "description");
@@ -131,30 +204,42 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                     Success = true,
                     Message = "Dell support page parsed successfully.",
                     LookupStatus = "success",
-                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestUrl : canonicalUrl,
+                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestedUrl : canonicalUrl,
                     DeviceInfo = new ScrapedDeviceInfo
                     {
                         ProductName = title,
-                        Manufacturer = manufacturer,
-                        ModelNumber = modelNumber,
-                        SerialNumber = query,
+                        Manufacturer = string.IsNullOrWhiteSpace(manufacturer) ? "Dell" : manufacturer,
+                        ModelNumber = string.IsNullOrWhiteSpace(modelNumber) ? serial : modelNumber,
+                        SerialNumber = serial,
                         Description = description,
                         ImageUrl = imageUrl,
-                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? response.RequestMessage?.RequestUri?.ToString() ?? requestUrl : canonicalUrl,
+                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? responseUrl ?? requestedUrl : canonicalUrl,
                         SourceType = ScrapeSourceType.VendorWebsite
                     }
                 };
             }
 
-            if (responseBody.Contains("Access Denied", StringComparison.OrdinalIgnoreCase)
-                || responseBody.Contains("403", StringComparison.OrdinalIgnoreCase))
+            // If JSON-LD is missing but a specific Dell page title exists, keep a best-effort result.
+            if (!string.IsNullOrWhiteSpace(title)
+                && !title.Contains("support home", StringComparison.OrdinalIgnoreCase)
+                && !title.Contains("access denied", StringComparison.OrdinalIgnoreCase))
             {
                 return new ScrapeResult
                 {
-                    Success = false,
-                    Message = "Dell support page blocked the request.",
-                    LookupStatus = "blocked",
-                    SuggestedLookupUrl = requestUrl
+                    Success = true,
+                    Message = "Dell support page returned a best-effort match.",
+                    LookupStatus = "partial_success",
+                    SuggestedLookupUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? requestedUrl : canonicalUrl,
+                    DeviceInfo = new ScrapedDeviceInfo
+                    {
+                        ProductName = title,
+                        Manufacturer = "Dell",
+                        ModelNumber = serial,
+                        SerialNumber = serial,
+                        Description = description,
+                        SourceUrl = string.IsNullOrWhiteSpace(canonicalUrl) ? responseUrl ?? requestedUrl : canonicalUrl,
+                        SourceType = ScrapeSourceType.VendorWebsite
+                    }
                 };
             }
 
@@ -163,7 +248,7 @@ namespace HomeLabManager.API.Services.Scraping.Providers
                 Success = false,
                 Message = "Dell support page did not contain recognized product information.",
                 LookupStatus = "not_found",
-                SuggestedLookupUrl = requestUrl
+                SuggestedLookupUrl = requestedUrl
             };
         }
 

--- a/HomeLabManager.API/Services/Scraping/ScraperService.cs
+++ b/HomeLabManager.API/Services/Scraping/ScraperService.cs
@@ -38,8 +38,28 @@ namespace HomeLabManager.API.Services.Scraping
                     return result;
                 }
 
+                // If a vendor provider explicitly says "manual lookup required" and gives a URL,
+                // preserve that authoritative guidance instead of falling through to generic web search.
+                if (!string.IsNullOrWhiteSpace(detectedVendor)
+                    && !string.IsNullOrWhiteSpace(result.DetectedVendor)
+                    && string.Equals(result.DetectedVendor, detectedVendor, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(result.LookupStatus, "manual_lookup_required", StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(result.SuggestedLookupUrl))
+                {
+                    return result;
+                }
+
+                var lastIsUnconfirmedManual = !string.IsNullOrWhiteSpace(detectedVendor)
+                    && lastFailure != null
+                    && string.Equals(lastFailure.LookupStatus, "manual_lookup_required", StringComparison.OrdinalIgnoreCase)
+                    && (string.IsNullOrWhiteSpace(lastFailure.DetectedVendor)
+                        || !string.Equals(lastFailure.DetectedVendor, detectedVendor, StringComparison.OrdinalIgnoreCase));
+
+                var currentIsManual = string.Equals(result.LookupStatus, "manual_lookup_required", StringComparison.OrdinalIgnoreCase);
+
                 if (lastFailure == null
-                    || (!string.IsNullOrWhiteSpace(result.SuggestedLookupUrl) && string.IsNullOrWhiteSpace(lastFailure.SuggestedLookupUrl)))
+                    || (!string.IsNullOrWhiteSpace(result.SuggestedLookupUrl) && string.IsNullOrWhiteSpace(lastFailure.SuggestedLookupUrl))
+                    || (lastIsUnconfirmedManual && !currentIsManual))
                 {
                     lastFailure = result;
                 }

--- a/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
+++ b/HomeLabManager.API/Services/Scraping/SerialVendorDetector.cs
@@ -10,13 +10,20 @@ namespace HomeLabManager.API.Services.Scraping
             }
 
             var normalizedSerial = serial.Trim();
+            var alphanumericSerial = new string(normalizedSerial.Where(char.IsLetterOrDigit).ToArray());
 
-            if (IsLikelyDellServiceTag(normalizedSerial))
+            if (normalizedSerial.Contains("CISCO", StringComparison.OrdinalIgnoreCase)
+                || alphanumericSerial.StartsWith("CISCO", StringComparison.OrdinalIgnoreCase))
+            {
+                return "Cisco";
+            }
+
+            if (IsLikelyDellServiceTag(alphanumericSerial))
             {
                 return "Dell";
             }
 
-            if (IsLikelyCiscoSerialNumber(normalizedSerial))
+            if (IsLikelyCiscoSerialNumber(alphanumericSerial))
             {
                 return "Cisco";
             }

--- a/HomeLabManager.WEBUI/Components/Pages/Vendors.razor
+++ b/HomeLabManager.WEBUI/Components/Pages/Vendors.razor
@@ -1,8 +1,195 @@
 @page "/vendors"
+@using System.Net.Http.Json
+@using HomeLabManager.WEBUI.Models
+@rendermode InteractiveServer
+@inject IHttpClientFactory HttpClientFactory
 
 <PageTitle>Vendors</PageTitle>
 
 <div class="container py-4">
 	<h1>Vendors</h1>
-	<p class="text-muted">View and manage vendor information for registered devices.</p>
+	<p class="text-muted">Browse vendor summaries for your current inventory.</p>
+
+	@* Page state flow:
+	   1) Loading state while API request is in flight
+	   2) Error state if API request fails
+	   3) Empty state if no vendor rows exist
+	   4) Normal state with summary cards + search + cards + table *@
+	@if (isLoading)
+	{
+		<p>Loading vendors...</p>
+	}
+	else if (!string.IsNullOrWhiteSpace(errorMessage))
+	{
+		<p class="text-danger">@errorMessage</p>
+	}
+	else if (vendors.Count == 0)
+	{
+		<div class="alert alert-secondary" role="alert">
+			No vendors found yet. Save a device and vendor entries will appear here.
+		</div>
+	}
+	else
+	{
+		@* Summary cards provide a quick snapshot without scanning the full table. *@
+		<div class="row g-3 mb-3">
+			<div class="col-12 col-md-4">
+				<div class="card shadow-sm h-100">
+					<div class="card-body">
+						<h6 class="text-uppercase text-muted mb-2">Total Vendors</h6>
+						<p class="fs-4 fw-semibold mb-0">@vendors.Count</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-12 col-md-4">
+				<div class="card shadow-sm h-100">
+					<div class="card-body">
+						<h6 class="text-uppercase text-muted mb-2">Vendors With Devices</h6>
+						<p class="fs-4 fw-semibold mb-0">@vendors.Count(v => v.DeviceCount > 0)</p>
+					</div>
+				</div>
+			</div>
+			<div class="col-12 col-md-4">
+				<div class="card shadow-sm h-100">
+					<div class="card-body">
+						<h6 class="text-uppercase text-muted mb-2">Vendors Without Devices</h6>
+						<p class="fs-4 fw-semibold mb-0">@vendors.Count(v => v.DeviceCount == 0)</p>
+					</div>
+				</div>
+			</div>
+		</div>
+
+		<div class="row g-3 mb-4">
+			<div class="col-12 col-md-6">
+				@* Client-side filter for vendor name; keeps UX instant for small/medium lists. *@
+				<input
+					class="form-control"
+					placeholder="Search vendors"
+					@bind="searchTerm"
+					@bind:event="oninput" />
+			</div>
+		</div>
+
+		@* Card grid is the primary visual for issue #33. *@
+		<div class="row g-3 mb-4">
+			@foreach (var vendor in FilteredVendors)
+			{
+				<div class="col-12 col-md-6 col-xl-4">
+					<div class="card shadow-sm h-100">
+						<div class="card-body d-flex flex-column">
+							<h5 class="card-title mb-1">@vendor.VendorName</h5>
+							<p class="text-muted small mb-3">Vendor ID: @vendor.Id</p>
+
+							<div class="d-flex justify-content-between mb-2">
+								<span class="text-muted">Products</span>
+								<strong>@vendor.ProductCount</strong>
+							</div>
+							<div class="d-flex justify-content-between mb-2">
+								<span class="text-muted">Devices</span>
+								<strong>@vendor.DeviceCount</strong>
+							</div>
+							<div class="d-flex justify-content-between mb-3">
+								<span class="text-muted">Last Seen</span>
+								<strong>@FormatDate(vendor.LastSeenUtc)</strong>
+							</div>
+
+							@if (!string.IsNullOrWhiteSpace(vendor.VendorBaseUrl))
+							{
+								<a class="btn btn-outline-primary btn-sm mt-auto"
+								   href="@vendor.VendorBaseUrl"
+								   target="_blank"
+								   rel="noopener noreferrer">
+									Visit Vendor Site
+								</a>
+							}
+							else
+							{
+								<span class="text-muted small mt-auto">No vendor URL configured</span>
+							}
+						</div>
+					</div>
+				</div>
+			}
+		</div>
+
+		<div class="table-responsive">
+			@* Table view gives a compact, sortable-friendly format for later enhancements. *@
+			<table class="table table-striped align-middle">
+				<thead>
+					<tr>
+						<th>Vendor</th>
+						<th>Products</th>
+						<th>Devices</th>
+						<th>Last Seen (UTC)</th>
+						<th>Website</th>
+					</tr>
+				</thead>
+				<tbody>
+					@foreach (var vendor in FilteredVendors)
+					{
+						<tr>
+							<td>@vendor.VendorName</td>
+							<td>@vendor.ProductCount</td>
+							<td>@vendor.DeviceCount</td>
+							<td>@FormatDate(vendor.LastSeenUtc)</td>
+							<td>
+								@if (!string.IsNullOrWhiteSpace(vendor.VendorBaseUrl))
+								{
+									<a href="@vendor.VendorBaseUrl" target="_blank" rel="noopener noreferrer">Open</a>
+								}
+								else
+								{
+									<span class="text-muted">N/A</span>
+								}
+							</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		</div>
+	}
 </div>
+
+@code {
+	private readonly List<VendorSummaryResponse> vendors = [];
+	private bool isLoading = true;
+	private string? errorMessage;
+	private string searchTerm = string.Empty;
+
+	protected override async Task OnInitializedAsync()
+	{
+		try
+		{
+			// Load vendor summary data from API once at page initialization.
+			var client = HttpClientFactory.CreateClient("HomeLabApi");
+			var result = await client.GetFromJsonAsync<List<VendorSummaryResponse>>("api/vendors");
+
+			if (result != null)
+			{
+				vendors.AddRange(result);
+			}
+		}
+		catch (Exception ex)
+		{
+			errorMessage = $"Failed to load vendors: {ex.Message}";
+		}
+		finally
+		{
+			isLoading = false;
+		}
+	}
+
+	private IEnumerable<VendorSummaryResponse> FilteredVendors =>
+		vendors
+			// Filter by vendor name and then rank by device count so active vendors float to top.
+			.Where(vendor =>
+				string.IsNullOrWhiteSpace(searchTerm)
+				|| vendor.VendorName.Contains(searchTerm, StringComparison.OrdinalIgnoreCase))
+			.OrderByDescending(vendor => vendor.DeviceCount)
+			.ThenBy(vendor => vendor.VendorName);
+
+	private static string FormatDate(DateTime? value)
+	{
+		return value.HasValue ? value.Value.ToString("u") : "Never";
+	}
+}

--- a/HomeLabManager.WEBUI/Models/VendorSummaryResponse.cs
+++ b/HomeLabManager.WEBUI/Models/VendorSummaryResponse.cs
@@ -1,0 +1,12 @@
+namespace HomeLabManager.WEBUI.Models
+{
+    public class VendorSummaryResponse
+    {
+        public Guid Id { get; set; }
+        public string VendorName { get; set; } = string.Empty;
+        public string? VendorBaseUrl { get; set; }
+        public int ProductCount { get; set; }
+        public int DeviceCount { get; set; }
+        public DateTime? LastSeenUtc { get; set; }
+    }
+}


### PR DESCRIPTION
Description:
- Added vendor deduplication in device save paths to reuse canonical vendor rows and avoid duplicate vendor records.
- Added vendor summary API endpoint and DTOs.
- Built vendors page UI with loading/error/empty states, summary cards, search, card grid, and table view.
- Improved Dell serial provider resiliency (multi-URL attempts, blocked detection, better manual lookup guidance, best-effort parsing).
- Improved scraper routing behavior for manual lookup vs fallback selection.
- Improved serial vendor detection for Cisco-prefixed inputs.
- Added tests:
  - DeviceService vendor dedup coverage
  - Serial vendor detector coverage
  - Scraper routing regression coverage (unknown-vendor/manual-lookup behavior)

Validation:
- dotnet test HomeLabManager.API.Test
- Resulting in all tests passing